### PR TITLE
These files shouldn't appear in the released version of the plugin

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,9 +9,11 @@ README.md export-ignore
 DEVELOPER.md export-ignore
 package.json export-ignore
 phpunit.xml.dist export-ignore
+.babelrc export-ignore
 .eslintrc export-ignore
 .eslintrc.js export-ignore
 .eslintignore export-ignore
+.jshintrc export-ignore
 .tx export-ignore
 webpack.config.js export-ignore
 postcss.config.js export-ignore


### PR DESCRIPTION
These files shouldn't appear in the released version of the plugin. We're unlikely to commit these to SVN by mistake, but it's still worth removing them from the release zip generated on GitHub.

### How to test the changes in this Pull Request:

1. In this GitHub project, navigate to the Code tab.
2. Select this branch in the "Branch:" dropdown list
3. Click "Clone or download", then "Download ZIP"
4. The zip file should not contain a `.jshintrc` or `.babelrc` file (ensure your OS is showing you hidden files)
5. Now select the master branch and repeat the download, this zip will contain the files (which is what we're fixing with this PR)