### PR TITLE
Bump tested up to versions for WordPress and WooCommerce

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, woothemes, akeda, jeffstieler, mikejolley, bor0, claudiosanches, royho, jamesrrodger, laurendavissmith001, dwainm, danreylop
 Tags: woocommerce, amazon, checkout, payments, e-commerce, ecommerce
 Requires at least: 4.4
-Tested up to: 5.4
+Tested up to: 5.5
 Stable tag: 1.12.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -15,8 +15,8 @@
  *
  * Text Domain: woocommerce-gateway-amazon-payments-advanced
  * Domain Path: /languages/
- * Tested up to: 5.4
- * WC tested up to: 4.1
+ * Tested up to: 5.5
+ * WC tested up to: 4.4
  * WC requires at least: 2.6
  *
  * Copyright: © 2020 WooCommerce


### PR DESCRIPTION
Now tested on WordPress 5.5 and WooCommerce 4.4.