### PR TITLE
Solve compatibility issues with Price Based on Country

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -463,7 +463,7 @@ class WC_Amazon_Payments_Advanced_API {
 	 */
 	public static function get_selected_currencies() {
 		$settings = self::get_settings();
-		return isset( $settings['currencies_supported'] ) ? $settings['currencies_supported'] : array();
+		return isset( $settings['currencies_supported'] ) && is_array( $settings['currencies_supported'] ) ? $settings['currencies_supported'] : array();
 	}
 
 	/**

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
@@ -20,8 +20,8 @@ class WC_Amazon_Payments_Advanced_Multi_Currency {
 	 */
 	const COMPATIBLE_PLUGINS = array(
 		'global_WOOCS'                         => 'WOOCS – Currency Switcher for WooCommerce',
-		'global_woocommerce_wpml'              => 'WPML WooCommerce Multilingual',
 		'class_WC_Product_Price_Based_Country' => 'Price Based on Country for WooCommerce',
+		'global_woocommerce_wpml'              => 'WPML WooCommerce Multilingual',
 		'class_WC_Currency_Converter'          => 'Currency Converter Widget',
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

The pull request solves the following thread of the WordPress.org support forum:
https://wordpress.org/support/topic/not-compatible-with-price-based-on-country-for-woocommerce/

When the user has installed WPML and Price Based on Country, the multicurrency compatibility function detects first the WPML class. Since Price Based on Country requires that the user disable the WPML multicurrency option, "Amazon Pay" does not enable the multicurrency module because WMPL does not add any additional currencies.

Changing the order of the elements of the COMPATIBLE_PLUGINS constant array solves the issue (If Price Based on Country is active, the WMPL multicurrency option has to be disabled).

### How to test the changes in this Pull Request:

1. Install and activate PBoC and WMPL
2. Disable the multicurrency option of WMPL
3. Check that the multicurrency module is active in the Amazon pay settings page.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

* Fixed: Multicurrency compatibility is not detected when Price Based on Country and WMPL is active.
* Fixed: PHP error: "array_search() expects parameter 2 to be array" when the currencies_supported option is not set.
