### PR TITLE
Fix global checking condition so that it doesn't throw a warning.

### DIFF
--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency.php
@@ -152,7 +152,7 @@ class WC_Amazon_Payments_Advanced_Multi_Currency {
 			if ( 0 === strpos( $definition_name, 'global' ) ) {
 				$global_name = str_replace( 'global_', '', $definition_name );
 
-				if ( $GLOBALS[ $global_name ] ) {
+				if ( isset( $GLOBALS[ $global_name ] ) && $GLOBALS[ $global_name ] ) {
 					$match = true;
 				}
 			} elseif ( 0 === strpos( $definition_name, 'class' ) ) {


### PR DESCRIPTION
Fixes a couple of warnings that prevent the plugin from working if WP_DEBUG_DISPLAY is enabled