### PR TITLE
Exclude wordpress_org_assets from build zip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,3 +29,4 @@ jest-puppeteer.config.js export-ignore
 default.env export-ignore
 docker-compose.yml export-ignore
 docs/DOCKER.md export-ignore
+wordpress_org_assets export-ignore


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Exclude wordpress_org_assets from build zip

### How to test the changes in this Pull Request:

1. Run `npm run build`
2. Check generated zip archive contents, `wordpress_org_assets` shouldn't be there.
3. Running the same test on main contains the assets folder.

### Changelog entry

N/A