### PR TITLE
Only toggle visibility when we're on an Amazon Checkout session

### DIFF
--- a/assets/js/amazon-app-widgets.js
+++ b/assets/js/amazon-app-widgets.js
@@ -683,10 +683,10 @@ jQuery( function( $ ) {
 	}
 
 	$( 'body' ).on( 'updated_checkout', function() {
-		toggleFieldVisibility( 'shipping', 'state' );
 		if( ! isAmazonCheckout() ) {
 			return;
 		}
+		toggleFieldVisibility( 'shipping', 'state' );
 		if ( $( '.woocommerce-billing-fields .woocommerce-billing-fields__field-wrapper > *' ).length > 0 ) {
 			$( '.woocommerce-billing-fields' ).insertBefore( '#payment' );
 		}


### PR DESCRIPTION
This fixes #83. Along with several zendesk tickets related to 1.13.0

Before this PR, to reproduce the issue you need to:

1. Be a guest (according to our QA team this happened also while being logged in, but for me it didn't)
2. Do not log into amazon
3. Attempt to go to checkout
4. After the screen updates from a billing address change (or even on load), the shipping fields would dissapear.