### PR TITLE
Fix critical issue with CV1 settings

### DIFF
--- a/assets/js/amazon-wc-admin.js
+++ b/assets/js/amazon-wc-admin.js
@@ -110,6 +110,7 @@
 			}
 		},
 		payment_region_on_change: function() {
+			$( '.wcapa-seller-central-secret-key-url' ).attr('href', amazon_admin_params.secret_keys_urls[ wc_simple_path_form.get_region_selected() ] );
 			if ( 'jp' === wc_simple_path_form.get_region_selected() ) {
 				// JP does not have Simple Path Registration, we open a new url for it.
 				wc_simple_path_form.register_now_link.attr( 'href', wc_simple_path_form.get_simple_path_url() );
@@ -349,7 +350,13 @@
 		},
 		toggle_visibility: function( e ) {
 			e.preventDefault();
-			$( $( this ).data( 'toggle' ) ).toggleClass( 'hidden' );
+			var target = $( $( this ).data( 'toggle' ) );
+			target.toggleClass( 'hidden' );
+			if ( ! $( this ).hasClass( 'wcapa-toggle-scroll' ) ) {
+				return;
+			}
+			var body = $( 'html, body' );
+			body.stop().animate( { scrollTop: target.offset().top - 100 }, 1000, 'swing' );
 		}
 	};
 	if ( $( 'body' ).hasClass( 'woocommerce_page_wc-settings' ) ) {

--- a/includes/admin/class-wc-amazon-payments-advanced-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-admin.php
@@ -108,7 +108,55 @@ class WC_Amazon_Payments_Advanced_Admin {
 		$this->settings = WC_Amazon_Payments_Advanced_API::get_settings();
 		global $current_section;
 
+		$login_app_enabled         = 'yes' === $this->settings['enable_login_app'];
+		$wc_version_3_9_or_greater = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.9', '>=' );
+
+		// If we are running WooCommerce 3.9 and up we want the store to be running with the Login App enabled. This
+		// allows us to use the features of Login to properly populate order information that these version of
+		// WooCommerce expect (as well as other plugins).
+		$current_screen = get_current_screen();
+
+		// Send out a different notification if we're on the Amazon Pay settings screen. Non-dismissable when on the
+		// settings screen, dismissable if we're anywhere else.
+		if ( isset( $current_screen ) &&
+			'woocommerce_page_wc-settings' === $current_screen->id &&
+			'amazon_payments_advanced' === $current_section
+		) {
+			$in_settings                    = true;
+			$in_amazon_pay_settings_section = 'in_settings';
+			$is_dismissable                 = false;
+		} else {
+			$in_settings                    = false;
+			$in_amazon_pay_settings_section = '';
+			$is_dismissable                 = true;
+		}
+
 		$notices = array();
+
+		$gateway = wc_apa()->get_gateway();
+
+		if ( $gateway->has_v1_settings() && ! $gateway->is_v1_configured() ) {
+			if ( ! $in_settings ) {
+				$notices[] = array(
+					'dismiss_action' => 'amazon_pay_dismiss_cv1_broken',
+					'class'          => 'notice notice-warning',
+					'text'           => sprintf(
+						/* translators: 1) The URL to the Amazon Pay settings screen. */
+						'<p>' . __( 'Your Amazon Pay legacy settings seem corrupted. If you see issues processing legacy orders/subscriptions. Please follow the instructions in the <a href="%1$s">Amazon Pay Settings</a> to go through a recovery process.', 'woocommerce-gateway-amazon-payments-advanced' ) . '</p>',
+						esc_url( $this->get_settings_url() )
+					),
+					'is_dismissable' => false,
+				);
+			} else {
+				$notices[] = array(
+					'dismiss_action' => 'amazon_pay_dismiss_cv1_broken',
+					'class'          => 'notice notice-warning',
+					'text'           => '<p>' . __( 'Your Amazon Pay legacy settings seem corrupted. If you see issues processing legacy orders/subscriptions. Please follow the instructions in the <a href="#" class="wcapa-toggle-section wcapa-toggle-scroll"  data-toggle="#v1-settings-container">Previous Version Configuration</a> area go through a recovery process.', 'woocommerce-gateway-amazon-payments-advanced' ) . '</p>',
+					'is_dismissable' => false,
+				);
+			}
+			return $notices; // Return early, as this is a critical issue.
+		}
 
 		if ( class_exists( 'WooCommerce_Germanized' ) && 'yes' === get_option( 'woocommerce_gzd_checkout_stop_order_cancellation' ) ) {
 			$notices[] = array(
@@ -141,29 +189,6 @@ class WC_Amazon_Payments_Advanced_Admin {
 				),
 				'is_dismissable' => true,
 			);
-		}
-
-		$login_app_enabled         = 'yes' === $this->settings['enable_login_app'];
-		$wc_version_3_9_or_greater = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.9', '>=' );
-
-		// If we are running WooCommerce 3.9 and up we want the store to be running with the Login App enabled. This
-		// allows us to use the features of Login to properly populate order information that these version of
-		// WooCommerce expect (as well as other plugins).
-		$current_screen = get_current_screen();
-
-		// Send out a different notification if we're on the Amazon Pay settings screen. Non-dismissable when on the
-		// settings screen, dismissable if we're anywhere else.
-		if ( isset( $current_screen ) &&
-			'woocommerce_page_wc-settings' === $current_screen->id &&
-			'amazon_payments_advanced' === $current_section
-		) {
-			$in_settings                    = true;
-			$in_amazon_pay_settings_section = 'in_settings';
-			$is_dismissable                 = false;
-		} else {
-			$in_settings                    = false;
-			$in_amazon_pay_settings_section = '';
-			$is_dismissable                 = true;
 		}
 
 		if ( $wc_version_3_9_or_greater && ! $login_app_enabled ) {
@@ -245,8 +270,10 @@ class WC_Amazon_Payments_Advanced_Admin {
 					$notice['text'],
 					array(
 						'a'      => array(
-							'href'  => array(),
-							'title' => array(),
+							'href'        => array(),
+							'title'       => array(),
+							'class'       => array(),
+							'data-toggle' => array(),
 						),
 						'strong' => array(),
 						'em'     => array(),
@@ -332,6 +359,7 @@ class WC_Amazon_Payments_Advanced_Admin {
 			'woo_version'           => 'WooCommerce: ' . WC()->version,
 			'plugin_version'        => 'WooCommerce Amazon Pay: ' . wc_apa()->version,
 			'language_combinations' => WC_Amazon_Payments_Advanced_API::get_languages_per_region(),
+			'secret_keys_urls'      => WC_Amazon_Payments_Advanced_API::get_secret_key_page_urls(), // LEGACY FIX.
 		);
 
 		wp_register_script( 'amazon_payments_admin', wc_apa()->plugin_url . '/assets/js/amazon-wc-admin' . $js_suffix, array(), wc_apa()->version, true );

--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -123,7 +123,6 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 			'payment_region'                  => self::get_payment_region_from_country( WC()->countries->get_base_country() ),
 			'enable_login_app'                => ( self::is_new_installation() ) ? 'yes' : 'no',
 			'app_client_id'                   => '',
-			'app_client_secret'               => '',
 			'sandbox'                         => 'yes',
 			'payment_capture'                 => 'no',
 			'authorization_mode'              => 'async',

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -855,4 +855,29 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 		return $obj;
 	}
 
+	/**
+	 * Get URLs from where to get the secret key in seller central, per region.
+	 *
+	 * @return array
+	 */
+	public static function get_secret_key_page_urls() {
+		return array(
+			'us' => 'https://sellercentral.amazon.com/gp/pyop/seller/mwsaccess',
+			'eu' => 'https://sellercentral-europe.amazon.com/gp/pyop/seller/mwsaccess',
+			'gb' => 'https://sellercentral-europe.amazon.com/gp/pyop/seller/mwsaccess',
+			'jp' => 'https://sellercentral-japan.amazon.com/gp/pyop/seller/mwsaccess',
+		);
+	}
+
+	/**
+	 * Get URL from where to get the secret key in seller central, for the current region.
+	 *
+	 * @return string|bool
+	 */
+	public static function get_secret_key_page_url() {
+		$region = self::get_settings( 'payment_region' );
+		$urls   = self::get_secret_key_page_urls();
+		return isset( $urls[ $region ] ) ? $urls[ $region ] : false;
+	}
+
 }

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -647,6 +647,20 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	}
 
 	/**
+	 * Get field value.
+	 *
+	 * @param string $key Field key.
+	 * @param array  $value Field value.
+	 * @return string
+	 */
+	public function validate_hidden_masked_field( $key, $value ) {
+		if ( ! empty( $this->settings[ $key ] ) ) {
+			$value = $this->settings[ $key ];
+		}
+		return $value;
+	}
+
+	/**
 	 * Admin Panel Options
 	 * - Options for bits like 'title' and availability on a country-by-country basis
 	 */


### PR DESCRIPTION
This contains a fix and a recovery flow for an issue that caused CV1 secret keys to be removed after saving settings on the gateway.

In order to reproduce the issue, you need to.

1. Install 1.13.1 (or earlier) version of the plugin.
2. Configure the plugin (do the onboarding). Save settings.
3. Attempt to operate, everything should work as usual.
3. Install the 2.0.0 or 2.0.1 version of the plugin.
4. Attempt to perform the upgrade process to CV2 keys (new onboarding), or just save the settings without doing the onboarding.
5. Any API communication attempted (a refresh on a status of an order, a checkout, anything), will not work.

With this version delivered here (tentatively 2.0.2 at the time of release):

* The issue doesn't happen any further. So new people updating won't get the error after saving settings (which is required to perform the upgrade).
* There's a warning for people that got the keys removed (secret_key and app_client_secret) with guidance as to how to recover from this situation and regain functionality of legacy API.
* App Client Secret (which is one of the corrupted keys), was asked to be removed since it's not used anymore by @bianchif.

---

Technical reason of the issue, we were using a custom field type to hide fields that shouldn't even be hidden fields in HTML. This resulted in fields without any input that was sent to the server, and without a `validate_{field_type}_value` function, that value ended up being empty, and then saved as such.

This function was added, alongside a recovery flow to enter the keys again.

---

Changelog tentative entry:

* Fix issue that caused secret key from CV1 to be lost after migrating to CV2.
* Allow recovery of CV1 secret key for people affected by the issue above.

---

Please let me know if anything else is required, and hopefully we can release this hotfix release tomorrow as it's affecting a lot of people.