### PR TITLE
2.0.3 Patch release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 *** Amazon Pay Changelog ***
 
+= 2.0.3 - 2021-xx-xx =
+* Fix issues with state level handling of shipping zones.
+* Fix issue that attempted to initialize the plugin in the REST API, throwing a fatal error.
+* Fix issue with subscriptions and checkout session validation, which forced customers to login again.
+* Added logging when users are asked to log in again, to debug other potential issues with this validation. 
+
 = 2.0.2 - 2021-05-26 =
 * Fix - Issue that caused secret key from pre v2 to be lost after migrating to v2.
 * Add - Allow recovery of v1 secret key if lost during migration to v2.

--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -105,7 +105,7 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 	 *
 	 * @param  string $key Key, if retrieving a single key.
 	 *
-	 * @return array
+	 * @return array|mixed
 	 */
 	public static function get_settings( $key = null ) {
 		$settings_options_name = 'woocommerce_amazon_payments_advanced_settings';

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -232,9 +232,8 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 
 			foreach ( $countries as $location ) {
 				$country = $location->code;
-				if ( ! isset( $zones[ $country ] ) ) {
-					$zones[ $country ] = new stdClass(); // If we use an empty array it'll be treated as an array in JSON.
-				}
+				// We're forcing it to be an empty, since it will override if the full country is allowed anywhere.
+				$zones[ $country ] = new stdClass(); // If we use an empty array it'll be treated as an array in JSON.
 			}
 
 			foreach ( $states as $location ) {
@@ -242,11 +241,13 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 				$country        = strtoupper( $location_codes[0] );
 				$state          = $location_codes[1];
 				if ( ! isset( $zones[ $country ] ) ) {
-					$zones[ $country ] = new stdClass(); // If we use an empty array it'll be treated as an array in JSON.
-				}
-
-				if ( ! isset( $zones[ $country ]->statesOrRegions ) ) {
+					$zones[ $country ]                  = new stdClass(); // If we use an empty array it'll be treated as an array in JSON.
 					$zones[ $country ]->statesOrRegions = array();
+				} else {
+					if ( ! isset( $zones[ $country ]->statesOrRegions ) ) {
+						// Do not override anything if the country is allowed fully.
+						continue;
+					}
 				}
 
 				$zones[ $country ]->statesOrRegions[] = $state;

--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -48,6 +48,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 		add_filter( 'woocommerce_amazon_pa_processed_order_redirect', array( $this, 'maybe_redirect_to_subscription' ), 10, 2 );
 		add_filter( 'woocommerce_amazon_pa_admin_meta_box_post_types', array( $this, 'add_subscription_post_type' ) );
 		add_filter( 'woocommerce_amazon_pa_order_admin_actions', array( $this, 'remove_charge_permission_actions_on_recurring' ), 10, 2 );
+		add_filter( 'woocommerce_amazon_pa_invalid_session_property', array( $this, 'ignore_amounts_in_session_validation' ), 10, 2 );
 
 		if ( 'v2' === strtolower( $version ) ) { // These only execute after the migration (not before).
 			add_filter( 'woocommerce_amazon_pa_create_checkout_session_params', array( $this, 'recurring_checkout_session' ) );
@@ -793,5 +794,25 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 			unset( $actions['authorize_capture'] );
 		}
 		return $actions;
+	}
+
+	/**
+	 * Ignore recurring properties
+	 *
+	 * @param  bool   $valid Wether the data is invalid or not.
+	 * @param  object $data Order object.
+	 * @return bool
+	 */
+	public function ignore_amounts_in_session_validation( $valid, $data ) {
+		if ( $valid ) {
+			return $valid;
+		}
+
+		switch ( $data->prop ) {
+			case 'recurringMetadata.amount.amount':
+				return true; // returning true turns ignores the invalid value, and considers it valid.
+		}
+
+		return $valid;
 	}
 }

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1617,9 +1617,10 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 *
 	 * @param  mixed $current Compare source.
 	 * @param  mixed $desired Optional. Desired values to compare against.
-	 * @return bool
+	 * @param  mixed $path    Optional. Current property path, to add to the error data. Used recursively.
+	 * @return bool|WP_Error
 	 */
-	private function validate_session_properties( $current, $desired = null ) {
+	private function validate_session_properties( $current, $desired = null, $path = array() ) {
 		$current = (array) $current;
 
 		if ( is_null( $desired ) ) {
@@ -1631,12 +1632,13 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		$desired = (array) $desired; // recast, just in case.
 
 		foreach ( $desired as $prop => $value ) {
+			array_push( $path, $prop );
 			if ( is_object( $value ) ) {
-				$valid = $this->validate_session_properties( $current[ $prop ], $value );
+				$valid = $this->validate_session_properties( $current[ $prop ], $value, $path );
 			} elseif ( is_array( $value ) ) {
 				if ( array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
 					// associative array, recurse.
-					$valid = $this->validate_session_properties( $current[ $prop ], $value );
+					$valid = $this->validate_session_properties( $current[ $prop ], $value, $path );
 				} else {
 					// sequential array, which might be in different order, so lets just diff.
 					$valid = array_diff( $value, $current[ $prop ] );
@@ -1645,9 +1647,32 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			} else {
 				$valid = $current[ $prop ] === $value;
 			}
-			if ( ! $valid ) {
+
+			if ( false === $valid ) {
+				$full_prop = implode( '.', $path );
+
+				$data = (object) array(
+					'prop'      => $full_prop,
+					'is'        => $current[ $prop ],
+					'should_be' => $value,
+				);
+
+				$valid = apply_filters( 'woocommerce_amazon_pa_invalid_session_property', $valid, $data );
+
+				if ( false === $valid ) {
+					$valid = new WP_Error(
+						'invalid_prop',
+						sprintf( 'Invalid property \'%s\'', $full_prop ),
+						$data
+					);
+					return $valid;
+				}
+			}
+
+			if ( is_wp_error( $valid ) ) {
 				return $valid;
 			}
+			array_pop( $path );
 		}
 		return true;
 	}
@@ -1663,12 +1688,13 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			return new WP_Error( 'force_refresh', $this->get_force_refresh() );
 		}
 
-		if ( ! $this->validate_session_properties( $checkout_session ) ) {
-			return new WP_Error( 'session_changed', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+		$props_validation = $this->validate_session_properties( $checkout_session );
+		if ( is_wp_error( $props_validation ) ) {
+			return new WP_Error( 'session_changed', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $props_validation->get_error_data() );
 		}
 
 		if ( 'Open' !== $checkout_session->statusDetails->state ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			return new WP_Error( 'not_open', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+			return new WP_Error( 'not_open', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $checkout_session->statusDetails->state ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 
 		if ( $checkout_session->productType !== $this->get_current_cart_action() ) { // phpcs:ignore WordPress.NamingConventions
@@ -1686,6 +1712,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	public function maybe_render_login_button_again( $checkout_session, $wrap = true ) {
 		$is_valid = $this->is_checkout_session_still_valid( $checkout_session );
 		if ( is_wp_error( $is_valid ) ) {
+			wc_apa()->log( $is_valid );
 			$this->render_login_button_again( $is_valid->get_error_message(), $wrap );
 			return;
 		}

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -105,6 +105,10 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 * Load handlers for cart and orders after WC Cart is loaded.
 	 */
 	public function init_handlers() {
+		if ( is_null( WC()->cart ) ) {
+			return;
+		}
+
 		$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
 
 		if ( ! isset( $available_gateways[ $this->id ] ) ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1627,8 +1627,17 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		$desired = (array) $desired; // recast, just in case.
 
 		foreach ( $desired as $prop => $value ) {
-			if ( is_object( $value ) || is_array( $value ) ) {
+			if ( is_object( $value ) ) {
 				$valid = $this->validate_session_properties( $current[ $prop ], $value );
+			} elseif ( is_array( $value ) ) {
+				if ( array_keys( $value ) !== range( 0, count( $value ) - 1 ) ) {
+					// associative array, recurse.
+					$valid = $this->validate_session_properties( $current[ $prop ], $value );
+				} else {
+					// sequential array, which might be in different order, so lets just diff.
+					$valid = array_diff( $value, $current[ $prop ] );
+					$valid = count( $valid ) === 0;
+				}
 			} else {
 				$valid = $current[ $prop ] === $value;
 			}

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -299,9 +299,9 @@ class WC_Amazon_Payments_Advanced {
 	 *
 	 * @since 1.6.0
 	 *
-	 * @param string      $message Log message.
-	 * @param null|mixed  $object Data to be printed for more detail about the entry.
-	 * @param null|string $context Context for the log.
+	 * @param string|WP_Error $message Log message.
+	 * @param null|mixed      $object Data to be printed for more detail about the entry.
+	 * @param null|string     $context Context for the log.
 	 */
 	public function log( $message, $object = null, $context = null ) {
 		if ( empty( $this->settings['debug'] ) ) {
@@ -314,6 +314,14 @@ class WC_Amazon_Payments_Advanced {
 
 		if ( ! is_a( $this->logger, 'WC_Logger' ) ) {
 			$this->logger = new WC_Logger();
+		}
+
+		if ( is_wp_error( $message ) ) {
+			$error_data = $message->get_error_data();
+			if ( ! is_null( $error_data ) ) {
+				$object = $error_data;
+			}
+			$message = $message->get_error_message();
 		}
 
 		if ( empty( $context ) ) {


### PR DESCRIPTION
We're addressing several issues here:

* When shipping restrictions are in place to a state level (some Shipping Zone only applies to some states, and the whole country is not allowed), the order of the states would sometimes be returned in a different order than what is sent. This is now fixed.
* Allow the full country if some shipping zone allows it, instead of restricting it to some states allowed in other zones. In other words, be generous. Eg: Zone 1 : `US -> Flat Rate` and Zone 2: `NY, NJ, FL -> USPS`. All US addresses are allowed. This wasn't the case before this fix.
* If there's no cart object, do not initialize frontend parts of the plugin. This was causing issues with the WP REST API in some cases.
* Checkout Session validation was improved to exclude certain parameters which failed upon shipping costs recalculations.
* Also when the user is asked to log in again, this is logged with more contextual information and to get some idea of the issue.

This would address several zendesk tickets and WP.org issues and should be released as soon as possible. The code here went through QA on our side (SAU/CAL), and on Amazon's side (@bianchif)

Let me know of any issues found, or notify me of the release.