### PR TITLE
Little translation fix of the Change button

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -926,8 +926,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( ! empty( $checkout_session->shippingAddress ) ) : // phpcs:ignore WordPress.NamingConventions
 			?>
 			<div id="shipping_address_widget">
+				<?php
+				$change_label = esc_html__( 'Change', 'woocommerce-gateway-amazon-payments-advanced' );
+				?>
 				<h3>
-					<a href="#" class="wc-apa-widget-change" id="shipping_address_widget_change">Change</a>
+					<a href="#" class="wc-apa-widget-change" id="shipping_address_widget_change"><?php echo $change_label; ?></a>
 					<?php esc_html_e( 'Shipping Address', 'woocommerce-gateway-amazon-payments-advanced' ); ?>
 				</h3>
 				<div class="shipping_address_display">
@@ -937,7 +940,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			<?php
 		endif;
 	}
-
+	
 	/**
 	 * Render layout for Amazon Checkout
 	 */


### PR DESCRIPTION
Translating the Change Label in all places

### All Submissions:

* [x ] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Currently the Change button is not translatable by a translation file, this is a little fix for it.