### PR TITLE
Add hook to formatted name

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -382,9 +382,13 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 		// Use fallback value for the last name to avoid field required errors.
 		$last_name_fallback = '.';
 		$names              = explode( ' ', $name );
-		return array(
-			'first_name' => array_shift( $names ),
-			'last_name'  => empty( $names ) ? $last_name_fallback : implode( ' ', $names ),
+		return apply_filters(
+			'woocommerce_amazon_pa_format_name',
+			array(
+				'first_name' => array_shift( $names ),
+				'last_name'  => empty( $names ) ? $last_name_fallback : implode( ' ', $names ),
+			),
+			$name
 		);
 	}
 


### PR DESCRIPTION
I want you to add a hook to the formatted name.
I want a hook that can handle first and last name formats.

### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

I want a hook that can handle first and last name formats.

Closes # .

### How to test the changes in this Pull Request:

1. Do test payment at my sandbox site.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

* Update - format_name hook added.