### PR TITLE
Fixes for issue 115 "Can not open order single order page"

### DIFF
--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -180,6 +180,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 
 		$charge_permission_status_label = $this->status_details_label( $charge_permission_cached_status );
 
+		$charge_permission_status_label = $charge_permission_status_label ? $charge_permission_status_label : __( 'Invalid', 'woocommerce-gateway-amazon-payments-advanced' );
 		/* translators: 1) Charge Permission ID 2) Status. */
 		echo wpautop( sprintf( __( 'Charge Permission %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $charge_permission_id ), esc_html( $charge_permission_status_label ) ) );
 
@@ -214,7 +215,7 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 			$charge_cached_status = wc_apa()->get_gateway()->get_cached_charge_status( $order );
 
 			$charge_status_label = $this->status_details_label( $charge_cached_status );
-
+			$charge_status_label = $charge_status_label ? $charge_status_label : __( 'Invalid', 'woocommerce-gateway-amazon-payments-advanced' );
 			/* translators: 1) Charge ID 2) Status. */
 			echo wpautop( sprintf( __( 'Charge %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $charge_id ), esc_html( $charge_status_label ) ) );
 

--- a/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
+++ b/includes/admin/class-wc-amazon-payments-advanced-order-admin.php
@@ -178,13 +178,13 @@ class WC_Amazon_Payments_Advanced_Order_Admin {
 
 		$charge_permission_cached_status = wc_apa()->get_gateway()->get_cached_charge_permission_status( $order );
 
-		$charge_permission_status_label = $this->status_details_label( $charge_permission_cached_status );
+		$charge_permission_status_label = ! is_wp_error( $charge_permission_cached_status ) ? $this->status_details_label( $charge_permission_cached_status ) : false;
 
 		$charge_permission_status_label = $charge_permission_status_label ? $charge_permission_status_label : __( 'Invalid', 'woocommerce-gateway-amazon-payments-advanced' );
 		/* translators: 1) Charge Permission ID 2) Status. */
 		echo wpautop( sprintf( __( 'Charge Permission %1$s is <strong>%2$s</strong>.', 'woocommerce-gateway-amazon-payments-advanced' ), esc_html( $charge_permission_id ), esc_html( $charge_permission_status_label ) ) );
 
-		$charge_permission_status = $charge_permission_cached_status->status;
+		$charge_permission_status = ! is_wp_error( $charge_permission_cached_status ) ? $charge_permission_cached_status->status : '';
 
 		switch ( $charge_permission_status ) {
 			case 'Chargeable':

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1882,6 +1882,10 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			$charge_permission_id = $charge_permission->chargePermissionId; // phpcs:ignore WordPress.NamingConventions
 		}
 
+		if ( is_wp_error( $charge_permission ) ) {
+			return $charge_permission;
+		}
+
 		$charge_permission_status       = $this->format_status_details( $charge_permission->statusDetails ); // phpcs:ignore WordPress.NamingConventions
 		$charge_permission_status->type = $charge_permission->chargePermissionType; // phpcs:ignore WordPress.NamingConventions
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- We catch all the Exceptions that can be thrown from handle_generic_api_response_errors() method to avoid Fatal errors.
- We check for WP_Error in auth_box_render() method to avoid PHP warnings.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #115 .

### How to test the changes in this Pull Request:

1. Subscriptions and orders completed via Amazon Pay should not throw fatal errors.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
