### PR TITLE
fix: Pay checkout fails when recurring payment frequency is passed as an integer

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -250,7 +250,14 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 		return array(
 			'unit'  => $apa_period,
-			'value' => $apa_interval,
+			/**
+			 * Amazon accepts the recurringMetadata.frequency.value as string.
+			 *
+			 * Casting $apa_interval to string ensures consistency.
+			 *
+			 * @see https://developer.amazon.com/docs/amazon-pay-api-v2/checkout-session.html#type-frequency
+			 */
+			'value' => (string) $apa_interval,
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Amazon accepts the recurringMetadata.frequency.value as string.
Casting $apa_interval to string ensures consistency.
https://developer.amazon.com/docs/amazon-pay-api-v2/checkout-session.html#type-frequency
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #122.

### How to test the changes in this Pull Request:

1. Install WooCommerce Subscriptions, All Products for Subscriptions and Amazon Pay
2. Create a simple product with a subscription option configured via All Products
3. You should be able to complete your transaction without warning or  fatal in the logs.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Cast recurringMetadata.frequency.value to string before passing it to Amazon API.
