### PR TITLE
fix: order changes status to Failed during the process

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1332,7 +1332,6 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		$this->maybe_set_transaction_id( $order, $charge_permission_id, $response->chargeId );
 
 		$order->save();
-		$this->log_charge_permission_status_change( $order );
 		$charge_id   = $response->chargeId; // phpcs:ignore WordPress.NamingConventions
 		$order_total = (float) $order->get_total( 'edit' );
 		if ( 0 >= $order_total ) {
@@ -1347,6 +1346,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				wc_maybe_reduce_stock_levels( $order->get_id() );
 			}
 		}
+		$this->log_charge_permission_status_change( $order );
 		$order->save();
 
 		do_action( 'woocommerce_amazon_pa_processed_order', $order, $response );
@@ -1522,7 +1522,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			case 'Closed':
 				$order_has_charge = is_null( $this->get_cached_charge_status( $order, true )->status );
 				if ( apply_filters( 'woocommerce_amazon_pa_charge_permission_status_should_fail_order', $order_has_charge, $order ) ) {
-					$order->update_status( 'failed' );
+					$order->update_status( 'failed', __( 'Amazon charge status was closed, moving order to failed.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 					wc_maybe_increase_stock_levels( $order->get_id() );
 				}
 				break;


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Method log_charge_permission_status_change was executed before log_charge_status_change. log_charge_permission_status_change was looking on a cached status, which there was none at that time, and if it was null (always was) was changing the order status to failed. Changing the order these methods are being executed, in order for log_charge_status_change to cache a charge status, fixes that issue.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #123 .

### How to test the changes in this Pull Request:

1. Go to site and add a One time payment product to Cart
2. Go to checkout and select Amazon Pay
3. Log in to Amazon shopper account and Pay
4. In the order's backend, there should be no note changing the order status to failed in any point.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Check for cached charge status after being initially cached.