### PR TITLE
Adds an Additional way of identifying order id on amazon return

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -766,7 +766,7 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 		$version_note = sprintf( __( 'Created by WC_Gateway_Amazon_Pay/%1$s (Platform=WooCommerce/%2$s)', 'woocommerce-gateway-amazon-payments-advanced' ), WC_AMAZON_PAY_VERSION, WC()->version );
 
 		return array(
-			'merchantReferenceId' => $order_id,
+			'merchantReferenceId' => apply_filters( 'apa_merchant_metadata_reference_id', $order_id ),
 			'merchantStoreName'   => WC_Amazon_Payments_Advanced::get_site_name(),
 			'customInformation'   => $version_note,
 		);

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -766,7 +766,7 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 		$version_note = sprintf( __( 'Created by WC_Gateway_Amazon_Pay/%1$s (Platform=WooCommerce/%2$s)', 'woocommerce-gateway-amazon-payments-advanced' ), WC_AMAZON_PAY_VERSION, WC()->version );
 
 		return array(
-			'merchantReferenceId' => apply_filters( 'apa_merchant_metadata_reference_id', $order_id ),
+			'merchantReferenceId' => apply_filters( 'woocommerce_amazon_pa_merchant_metadata_reference_id', $order_id ),
 			'merchantStoreName'   => WC_Amazon_Payments_Advanced::get_site_name(),
 			'customInformation'   => $version_note,
 		);

--- a/includes/class-wc-amazon-payments-advanced-ipn-handler.php
+++ b/includes/class-wc-amazon-payments-advanced-ipn-handler.php
@@ -458,7 +458,7 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 				throw new Exception( 'Not Implemented' );
 		}
 
-		$order_id = apply_filters( 'apa_merchant_metadata_reference_id_reverse', $order_id );
+		$order_id = apply_filters( 'woocommerce_amazon_pa_merchant_metadata_reference_id_reverse', $order_id );
 
 		if ( is_numeric( $order_id ) ) {
 			$order = wc_get_order( $order_id );

--- a/includes/class-wc-amazon-payments-advanced-ipn-handler.php
+++ b/includes/class-wc-amazon-payments-advanced-ipn-handler.php
@@ -458,6 +458,8 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 				throw new Exception( 'Not Implemented' );
 		}
 
+		$order_id = apply_filters( 'apa_merchant_metadata_reference_id_reverse', $order_id );
+
 		if ( is_numeric( $order_id ) ) {
 			$order = wc_get_order( $order_id );
 		} else {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1262,10 +1262,10 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			$order_id         = ! empty( $checkout_session->merchantMetadata->merchantReferenceId ) ? $checkout_session->merchantMetadata->merchantReferenceId : $order_id; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			/**
 			 * Merchants that use a filter to manipulate the merchantReferenceId provided to Amazon,
-			 * should migrate to apa_merchant_metadata_reference_id and implement the apa_merchant_metadata_reference_id_reverse
+			 * should migrate to woocommerce_amazon_pa_merchant_metadata_reference_id and implement the woocommerce_amazon_pa_merchant_metadata_reference_id_reverse
 			 * filter as well to provide the actual order's id when needed by the plugin.
 			 */
-			$order_id = apply_filters( 'apa_merchant_metadata_reference_id_reverse', $order_id );
+			$order_id = apply_filters( 'woocommerce_amazon_pa_merchant_metadata_reference_id_reverse', $order_id );
 		}
 
 		if ( empty( $order_id ) ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1257,6 +1257,17 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		}
 
 		if ( empty( $order_id ) ) {
+			$checkout_session = $this->get_checkout_session( true );
+			$order_id         = ! empty( $checkout_session->merchantMetadata->merchantReferenceId ) ? $checkout_session->merchantMetadata->merchantReferenceId : $order_id; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			/**
+			 * Merchants that use a filter to manipulate the merchantReferenceId provided to Amazon,
+			 * should migrate to apa_merchant_metadata_reference_id and implement the apa_merchant_metadata_reference_id_reverse
+			 * filter as well to provide the actual order's id when needed by the plugin.
+			 */
+			$order_id = apply_filters( 'apa_merchant_metadata_reference_id_reverse', $order_id );
+		}
+
+		if ( empty( $order_id ) ) {
 			wc_apa()->log( "Error: Order could not be found. Checkout Session ID: {$checkout_session_id}." );
 			wc_add_notice( __( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
 			return;

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1256,6 +1256,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			$order_id = absint( get_query_var( 'order-pay' ) );
 		}
 
+		/* Fallback in case WC()->session->order_awaiting_payment was unset by 3rd party. */
 		if ( empty( $order_id ) ) {
 			$checkout_session = $this->get_checkout_session( true );
 			$order_id         = ! empty( $checkout_session->merchantMetadata->merchantReferenceId ) ? $checkout_session->merchantMetadata->merchantReferenceId : $order_id; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Provides an additional method of identifying the order id , for which we need to complete the checkout session.
Introduces 2 new filters.
woocommerce_amazon_pa_merchant_metadata_reference_id - For enabling merchants to alter the merchantReferenceId provided to Amazon
woocommerce_amazon_pa_merchant_metadata_reference_id_reverse - For those merchants that use the above, or alter the plugins default value for merchantReferenceId in any way, a way to provide the order id back to the plugin.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #134 .

### How to test the changes in this Pull Request:

This issue was not reproducible, logs we saw from various merchant sites suggested that on the method handle_return sometimes the WC()->session->order_awaiting_payment variable was not set.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Additional way of identifying order id after amazon update_checkout_session
> Add - 2 new filters. Control over the value of merchantReferenceId provided to Amazon, but also a way to retrieve the original.
