### PR TITLE
Solves Amazon Pay shouldn't be available when not supported currency selected.

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-api-abstract.php
+++ b/includes/class-wc-amazon-payments-advanced-api-abstract.php
@@ -206,8 +206,8 @@ abstract class WC_Amazon_Payments_Advanced_API_Abstract {
 	 */
 	public static function is_region_supports_shop_currency() {
 		$region = self::get_region();
-		// Avoid interferences of external multi-currency plugins.
-		$currency = get_option( 'woocommerce_currency' );
+		// Take into consideration external multi-currency plugins when not supported multicurrency region.
+		$currency = apply_filters( 'woocommerce_amazon_pa_active_currency', get_option( 'woocommerce_currency' ) );
 
 		switch ( $region ) {
 			case 'eu':

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -763,7 +763,7 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 	 */
 	public static function get_merchant_metadata( $order_id ) {
 		/* translators: Plugin version */
-		$version_note = sprintf( __( 'Created by WC_Gateway_Amazon_Pay/%1$s (Platform=WooCommerce/%2$s)', 'woocommerce-gateway-amazon-payments-advanced' ), WC_AMAZON_PAY_VERSION, WC()->version );
+		$version_note = sprintf( 'Created by WC_Gateway_Amazon_Pay/%1$s (Platform=WooCommerce/%2$s)', WC_AMAZON_PAY_VERSION, WC()->version );
 
 		return array(
 			'merchantReferenceId' => $order_id,

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-abstract.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-abstract.php
@@ -61,14 +61,14 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 	/**
 	 * Get selected currency function.
 	 *
-	 * @deprecated [%release-version%]
+	 * @deprecated 2.1.2
 	 *
-	 * @abstract Used to be abstract up to version [%before-release-version%]. Has been replaced by get_active_currency.
+	 * @abstract Used to be abstract up to version 2.1.1. Has been replaced by get_active_currency.
 	 *
 	 * @return string
 	 */
 	public function get_selected_currency() {
-		_deprecated_function( __METHOD__, '[%release-version%]', 'WC_Amazon_Payments_Advanced_Multi_Currency_Abstract::get_active_currency' );
+		_deprecated_function( __METHOD__, '2.1.2', 'WC_Amazon_Payments_Advanced_Multi_Currency_Abstract::get_active_currency' );
 		return static::get_active_currency();
 	}
 
@@ -77,7 +77,7 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 	 *
 	 * @abstract It will be made abstract in future release, in order to give time to merchants extending this class to adjust their code.
 	 *
-	 * @since [%release-version%]
+	 * @since 2.1.2
 	 *
 	 * @return string
 	 */

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-abstract.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-abstract.php
@@ -49,7 +49,7 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 	 */
 	public function maybe_disable_due_to_unsupported_currency() {
 		// If selected currency is not compatible with Amazon.
-		if ( ! $this->is_currency_compatible( $this->get_selected_currency() ) ) {
+		if ( ! $this->is_currency_compatible( static::get_active_currency() ) ) {
 			add_filter( 'woocommerce_amazon_payments_init', '__return_false' );
 			return;
 		}
@@ -59,11 +59,31 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 	}
 
 	/**
-	 * Interface for get selected currency function
+	 * Get selected currency function.
+	 *
+	 * @deprecated [%release-version%]
+	 *
+	 * @abstract Used to be abstract up to version [%before-release-version%]. Has been replaced by get_active_currency.
 	 *
 	 * @return string
 	 */
-	abstract public function get_selected_currency();
+	public function get_selected_currency() {
+		_deprecated_function( __METHOD__, '[%release-version%]', 'WC_Amazon_Payments_Advanced_Multi_Currency_Abstract::get_active_currency' );
+		return static::get_active_currency();
+	}
+
+	/**
+	 * Interface for get active currency function
+	 *
+	 * @abstract It will be made abstract in future release, in order to give time to merchants extending this class to adjust their code.
+	 *
+	 * @since [%release-version%]
+	 *
+	 * @return string
+	 */
+	public static function get_active_currency() {
+		return get_woocommerce_currency();
+	}
 
 	/**
 	 * If Multi-currency plugin is frontend compatible, meaning all currency changes happens only on frontend level.
@@ -93,7 +113,7 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 		$original_currency = WC()->session->get( self::ORIGINAL_CURRENCY_SESSION );
 
 		if ( ! $original_currency ) {
-			WC()->session->set( self::ORIGINAL_CURRENCY_SESSION, $this->get_selected_currency() );
+			WC()->session->set( self::ORIGINAL_CURRENCY_SESSION, static::get_active_currency() );
 			WC()->session->set( self::CURRENCY_TIMES_SWITCHED_SESSION, 0 );
 		} else {
 			// Only increase once, on ajax checkout render.
@@ -133,7 +153,7 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 			$payload['paymentDetails'] = array();
 		}
 
-		$payload['paymentDetails']['presentmentCurrency'] = $this->get_selected_currency();
+		$payload['paymentDetails']['presentmentCurrency'] = static::get_active_currency();
 
 		return $payload;
 	}
@@ -173,7 +193,7 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 	 */
 	public function ajax_get_currency() {
 		check_ajax_referer( 'multi_currency_nonce', 'nonce' );
-		echo $this->get_selected_currency();
+		echo static::get_active_currency();
 		wp_die();
 	}
 
@@ -225,7 +245,7 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 			return $valid;
 		}
 
-		if ( $checkout_session->paymentDetails->presentmentCurrency !== $this->get_selected_currency() ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+		if ( static::get_active_currency() !== $checkout_session->paymentDetails->presentmentCurrency ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 			return new WP_Error( 'currency_changed', __( 'The selected currency changed, please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
 

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-ppbc.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-ppbc.php
@@ -46,7 +46,7 @@ class WC_Amazon_Payments_Advanced_Multi_Currency_PPBC extends WC_Amazon_Payments
 	 *
 	 * @return string
 	 */
-	public function get_selected_currency() {
+	public static function get_active_currency() {
 		// This is for sandbox mode, changing countries manually.
 		if ( isset( $_REQUEST['wcpbc-manual-country'] ) ) {
 			$manual_country = wc_clean( wp_unslash( $_REQUEST['wcpbc-manual-country'] ) );
@@ -66,8 +66,8 @@ class WC_Amazon_Payments_Advanced_Multi_Currency_PPBC extends WC_Amazon_Payments
 	 */
 	public function ajax_get_currency() {
 		check_ajax_referer( 'multi_currency_nonce', 'nonce' );
-		if ( $this->is_currency_compatible( $this->get_selected_currency() ) ) {
-			$currency = $this->get_selected_currency();
+		if ( $this->is_currency_compatible( self::get_active_currency() ) ) {
+			$currency = self::get_active_currency();
 		} else {
 			$currency = wcpbc_get_base_currency();
 		}

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-wccw.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-wccw.php
@@ -21,7 +21,7 @@ class WC_Amazon_Payments_Advanced_Multi_Currency_WCCW extends WC_Amazon_Payments
 	 *
 	 * @return string
 	 */
-	public function get_selected_currency() {
+	public static function get_active_currency() {
 		return get_woocommerce_currency();
 	}
 

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-woocs.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-woocs.php
@@ -12,20 +12,11 @@
  */
 class WC_Amazon_Payments_Advanced_Multi_Currency_Woocs extends WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 
-	/**
-	 * Holds WOOCS instance.
-	 *
-	 * @var WOOCS
-	 */
-	protected $woocs;
 
 	/**
 	 * Specify hooks where compatibility action takes place.
 	 */
 	public function __construct() {
-		global $WOOCS; // phpcs:ignore WordPress.NamingConventions
-		$this->woocs = $WOOCS; // phpcs:ignore WordPress.NamingConventions
-
 		$version = is_a( wc_apa()->get_gateway(), 'WC_Gateway_Amazon_Payments_Advanced_Legacy' ) ? 'v1' : 'v2';
 		if ( 'v1' === $version ) {
 			// Option woocs_restrike_on_checkout_page === 1 will hide switcher on checkout.
@@ -42,8 +33,9 @@ class WC_Amazon_Payments_Advanced_Multi_Currency_Woocs extends WC_Amazon_Payment
 	 *
 	 * @return string
 	 */
-	public function get_selected_currency() {
-		return $this->woocs->current_currency;
+	public static function get_active_currency() {
+		global $WOOCS; // phpcs:ignore WordPress.NamingConventions
+		return is_object( $WOOCS ) && ! empty( $WOOCS->current_currency ) ? $WOOCS->current_currency : get_woocommerce_currency(); // phpcs:ignore WordPress.NamingConventions
 	}
 
 	/**

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-wpml.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-wpml.php
@@ -39,7 +39,7 @@ class WC_Amazon_Payments_Advanced_Multi_Currency_WPML extends WC_Amazon_Payments
 	 *
 	 * @return string
 	 */
-	public function get_selected_currency() {
+	public static function get_active_currency() {
 		if ( ! WC()->session ) {
 			return get_woocommerce_currency();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
is_region_supports_shop_currency method was only checking the WooCommerce selected currency via the woocommerce_currency option. This should not be the case when we are in a region where multicurrency is not supported like Japan or US. In these cases, it should also try to detect if one of the compatible Multicurrency plugins is present and if so what's the selected checkout currency before determine compatibility with the Amazon API.

Also a small fix is introduced along in this PR, where customInformation in merchantMetadata wasn't needed to be translatable and it was causing issues when it was translated with the Amazon API.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #149 .

### How to test the changes in this Pull Request:

1. Onboard with JApan merchant on japan region.
2. Use WPML currency feature
3. with shopper select a currency that is not JPY
4. Amazon Pay should not be available for checkout anymore

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Regions that don't support multi-currency will have Amazon Pay disabled when a not supported currency is selected.
> Fix - customInformation in merchantMetadata will not be translatable anymore.
