### PR TITLE
prevents JS fatal when jQuery.Event is passed to renderButton

### DIFF
--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -159,6 +159,15 @@
 
 		function renderButton( buttonId, buttonSettingsFlag ) {
 			buttonId = buttonId || button_id;
+
+			/**
+			 * On lines 213-216, renderButton is being declared as the callback to jQuery Events.
+			 * As a result its being supplied with the callbacks variables.
+			 * We make sure here, our variables are set to their defaults when that happens.
+			 */
+			buttonId = buttonId instanceof $.Event ? button_id : buttonId;
+			buttonSettingsFlag = 'string' !== typeof buttonSettingsFlag ? null : buttonSettingsFlag;
+
 			attemptRefreshData( buttonSettingsFlag );
 			if ( 0 === $( buttonId ).length ) {
 				return;


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Was introduced in pull #165 and produces:
```
Uncaught AmazonPay:
Can not find element #pay_with_amazon_2 for amazon.Pay.renderButton.
```
![image](https://user-images.githubusercontent.com/29694484/167925893-13b126c1-bf18-4d29-8153-5d485414003f.png)

renderButton is being registered as a callback to jQuery Events, which pass always the Event as the first parameter. As a result the function was running with invalid parameters. We ensure that when that happens, params revert back to defaults.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
