### PR TITLE
Fix/ppbc currency change

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1858,6 +1858,20 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				$valid = $current[ $prop ] === $value;
 			}
 
+			/**
+			 * If the condition is true, that means that a multi currency plugin changed the
+			 * currency after the Amazon Pay button was initially clicked.
+			 * 
+			 * We shouldn't throw an error since Amazon Pay docs mention that using the currencyCode prop
+			 * during  updating checkout will also automatically update the checkout session's presentmentCurrency
+			 * prop if they are different.
+			 *
+			 * @see https://developer.amazon.com/docs/amazon-pay-checkout/multi-currency-integration.html#2-set-payment-currencycode
+			 */
+			if ( 'presentmentCurrency' === $prop && false === $valid ) {
+				$valid = true;
+			}
+
 			if ( false === $valid ) {
 				$full_prop = implode( '.', $path );
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1861,14 +1861,21 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			/**
 			 * If the condition is true, that means that a multi currency plugin changed the
 			 * currency after the Amazon Pay button was initially clicked.
-			 * 
+			 *
 			 * We shouldn't throw an error since Amazon Pay docs mention that using the currencyCode prop
-			 * during  updating checkout will also automatically update the checkout session's presentmentCurrency
+			 * during updating checkout will also automatically update the checkout session's presentmentCurrency
 			 * prop if they are different.
 			 *
 			 * @see https://developer.amazon.com/docs/amazon-pay-checkout/multi-currency-integration.html#2-set-payment-currencycode
 			 */
 			if ( 'presentmentCurrency' === $prop && false === $valid ) {
+				$valid = true;
+			}
+
+			/**
+			 * Same as above, but for subscriptions.
+			 */
+			if ( ( 'recurringMetadata.amount.currencyCode' === implode( '.', $path ) || 'recurringMetadata.amount.amount' === implode( '.', $path ) ) && false === $valid ) {
 				$valid = true;
 			}
 

--- a/includes/compats/class-wc-amazon-payments-advanced-multi-currency-abstract.php
+++ b/includes/compats/class-wc-amazon-payments-advanced-multi-currency-abstract.php
@@ -54,7 +54,6 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 			return;
 		}
 
-		add_filter( 'woocommerce_amazon_pa_is_checkout_session_still_valid', array( $this, 'is_checkout_session_still_valid' ), 10, 2 );
 		add_filter( 'woocommerce_amazon_pa_create_checkout_session_params', array( $this, 'set_presentment_currency' ) );
 		add_filter( 'woocommerce_amazon_pa_create_checkout_session_classic_params', array( $this, 'set_presentment_currency' ) );
 	}
@@ -233,25 +232,5 @@ abstract class WC_Amazon_Payments_Advanced_Multi_Currency_Abstract {
 		}
 		return false;
 	}
-
-	/**
-	 * Filters the validity of the current checkout_session
-	 *
-	 * @param  bool|WP_Error $valid Is the checkout_session_still_valid?.
-	 * @param  object        $checkout_session Checkout Session Object.
-	 * @return bool|WP_Error
-	 */
-	public function is_checkout_session_still_valid( $valid, $checkout_session ) {
-		if ( is_wp_error( $valid ) ) {
-			return $valid;
-		}
-
-		if ( static::get_active_currency() !== $checkout_session->paymentDetails->presentmentCurrency ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName
-			return new WP_Error( 'currency_changed', __( 'The selected currency changed, please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ) );
-		}
-
-		return $valid;
-	}
-
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Amazon Pay Multicurrency docs [here](https://developer.amazon.com/docs/amazon-pay-checkout/multi-currency-integration.html)

Plugins like  WooCommerce Price Based on Country may change the currency after the Amazon Pay has been initially clicked (as a result Amazon's Pay checkout session initiated).
During that time, if a multicurrency compatible  plugin  is in use, a property presentmentCurrency will be set for the Checkout Session to be initiated. There is a chance though that the currency may change after the checkout session has been initiated. The plugin was performing strict validations to ensure that the checkout session is still valid, but this should be the case for  the  presentmentCurrency property since  it can be updated during the checkout phase by  the property chargeAmount.currencyCode (paragraph 2 in the Amazon Pay Docs).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #191.

### How to test the changes in this Pull Request:

1. Amazon Pay Settings should support more than one currency
2. Priced Based on country should be installed and Price zone should be configured.
3. With customer add product to cart and go to Checkout.
4. Log in to Amazon Pay testing account and select an address that will change the currency (based on configuration on step 2)
5. After returning to the checkout, the process should continue without any  errors

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Skip validating Checkout Session's currenciy properties.
