### PR TITLE
Hotfix/possible fatals

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1776,6 +1776,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 			$needs_shipping = count( $order->get_items( 'shipping' ) ) > 0;
 		} else {
+			// If the cart is not set, we are on the backend. So lets bail.
+			if ( empty( WC()->cart ) ) {
+				return false;
+			}
+
 			$needs_shipping = WC()->cart->needs_shipping();
 		}
 		return apply_filters( 'woocommerce_amazon_pa_current_cart_action', $needs_shipping ? 'PayAndShip' : 'PayOnly' );

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1766,8 +1766,8 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 */
 	public function get_current_cart_action() {
 		if ( is_wc_endpoint_url( 'order-pay' ) ) {
-			$order_id       = get_query_var( 'order-pay' );
-			$order          = wc_get_order( $order_id );
+			$order_id = get_query_var( 'order-pay' );
+			$order    = wc_get_order( $order_id );
 
 			// If we can't retrieve the order, lets bail.
 			if ( ! is_a( $order, 'WC_Order' ) ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1768,6 +1768,12 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		if ( is_wc_endpoint_url( 'order-pay' ) ) {
 			$order_id       = get_query_var( 'order-pay' );
 			$order          = wc_get_order( $order_id );
+
+			// If we can't retrieve the order, lets bail.
+			if ( ! is_a( $order, 'WC_Order' ) ) {
+				return false;
+			}
+
 			$needs_shipping = count( $order->get_items( 'shipping' ) ) > 0;
 		} else {
 			$needs_shipping = WC()->cart->needs_shipping();


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #192
Closes #196 

### How to test the changes in this Pull Request:

1. No Fatal should be thrown in /wp-admin/widgets.php page
2. Visit the order-pay endpoint with an INVALID order id, no fatal should trigger from the amazon pay plugin.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fatal on widgets page
> Fix - Fatal when order can't be retrieved on order-pay endpoint
