### PR TITLE
validating amazon connectivity before displaying Amazon Pay

### DIFF
--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -450,16 +450,6 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 	 * @return array
 	 */
 	public static function get_create_checkout_session_config( $redirect_url = null ) {
-		$valid_settings = self::validate_api_settings();
-		if ( is_wp_error( $valid_settings ) ) {
-			wc_apa()->get_gateway()->update_option( 'amazon_keys_setup_and_validated', 0 );
-			return array(
-				'publicKeyId' => '',
-				'payloadJSON' => '',
-				'signature'   => '',
-			);
-		}
-
 		$settings = self::get_settings();
 		$client   = self::get_client();
 		$payload  = self::create_checkout_session_params( $redirect_url );
@@ -479,16 +469,6 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 	 * @return array
 	 */
 	public static function get_create_checkout_classic_session_config( $payload ) {
-		$valid_settings = self::validate_api_settings();
-		if ( is_wp_error( $valid_settings ) ) {
-			wc_apa()->get_gateway()->update_option( 'amazon_keys_setup_and_validated', 0 );
-			return array(
-				'publicKeyId' => '',
-				'payloadJSON' => '',
-				'signature'   => '',
-			);
-		}
-
 		$settings  = self::get_settings();
 		$signature = self::get_client()->generateButtonSignature( wp_json_encode( $payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 		return array(

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -109,7 +109,7 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 	 *
 	 * @return WP_Error|bool Error
 	 */
-	protected static function validate_api_settings() {
+	public static function validate_api_settings() {
 		$settings = self::get_settings();
 
 		if ( empty( $settings['merchant_id'] ) ) {
@@ -450,6 +450,16 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 	 * @return array
 	 */
 	public static function get_create_checkout_session_config( $redirect_url = null ) {
+		$valid_settings = self::validate_api_settings();
+		if ( is_wp_error( $valid_settings ) ) {
+			wc_apa()->get_gateway()->update_option( 'amazon_keys_setup_and_validated', 0 );
+			return array(
+				'publicKeyId' => '',
+				'payloadJSON' => '',
+				'signature'   => '',
+			);
+		}
+
 		$settings = self::get_settings();
 		$client   = self::get_client();
 		$payload  = self::create_checkout_session_params( $redirect_url );
@@ -469,6 +479,16 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 	 * @return array
 	 */
 	public static function get_create_checkout_classic_session_config( $payload ) {
+		$valid_settings = self::validate_api_settings();
+		if ( is_wp_error( $valid_settings ) ) {
+			wc_apa()->get_gateway()->update_option( 'amazon_keys_setup_and_validated', 0 );
+			return array(
+				'publicKeyId' => '',
+				'payloadJSON' => '',
+				'signature'   => '',
+			);
+		}
+
 		$settings  = self::get_settings();
 		$signature = self::get_client()->generateButtonSignature( wp_json_encode( $payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 		return array(

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -88,7 +88,12 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 */
 	protected function get_availability() {
 
-		if ( ! parent::is_available() || empty( $this->settings['merchant_id'] ) ) {
+		if ( ! parent::is_available() ) {
+			return false;
+		}
+
+		if ( is_wp_error( WC_Amazon_Payments_Advanced_API::validate_api_settings() ) ) {
+			wc_apa()->get_gateway()->update_option( 'amazon_keys_setup_and_validated', 0 );
 			return false;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Validate all Amazon Settings are present before assuming availability.

Closes #197 
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

1. If you partially provide the Amazon Creds, like for example missing the private key file, no fatal should be thrown on the Front end

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Avoid Fatal, when Amazon Connectivety details partially provided
