### PR TITLE
Feature: add estimated order amount to pay button

### DIFF
--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -189,6 +189,8 @@
 				var separator_id = '.wc-apa-button-separator';
 				var buttonSettings = getButtonSettings( buttonSettingsFlag );
 
+				console.log( buttonSettings );
+
 				var thisConfigHash = amazon_payments_advanced.create_checkout_session_hash;
 				var oldConfigHash = thisButton.data( 'amazonRenderedSettings' );
 				if ( typeof oldConfigHash !== 'undefined' ) {
@@ -258,7 +260,8 @@
 				placement: amazon_payments_advanced.placement,
 				buttonColor: amazon_payments_advanced.button_color,
 				checkoutLanguage: amazon_payments_advanced.button_language !== '' ? amazon_payments_advanced.button_language.replace( '-', '_' ) : undefined,
-				productType: amazon_payments_advanced.action
+				productType: amazon_payments_advanced.action,
+				estimatedOrderAmount: amazon_payments_advanced.estimated_order_amount,
 			};
 			if ( 'product' === buttonSettingsFlag ) {
 				obj.productType = amazon_payments_advanced.product_action;

--- a/assets/js/amazon-wc-checkout.js
+++ b/assets/js/amazon-wc-checkout.js
@@ -189,8 +189,6 @@
 				var separator_id = '.wc-apa-button-separator';
 				var buttonSettings = getButtonSettings( buttonSettingsFlag );
 
-				console.log( buttonSettings );
-
 				var thisConfigHash = amazon_payments_advanced.create_checkout_session_hash;
 				var oldConfigHash = thisButton.data( 'amazonRenderedSettings' );
 				if ( typeof oldConfigHash !== 'undefined' ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1751,9 +1751,9 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 * @param string $id The value to provide the id attribute of the script with.
 	 * @return void
 	 */
-	public function update_js( $id ) {
+	public function update_js( $id = '' ) {
 
-		if ( '' === $id ) {
+		if ( empty( $id ) ) {
 			$id = 'wc-apa-update-vals';
 		}
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -269,6 +269,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'checkout_session_id'            => $this->get_checkout_session_id(),
 				'button_language'                => $this->settings['button_language'],
 				'ledger_currency'                => $this->get_ledger_currency(),
+				'estimated_order_amount'         => $this->get_estimated_order_amount(),
 			),
 			$params
 		);
@@ -1750,13 +1751,19 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 * @param string $id The value to provide the id attribute of the script with.
 	 * @return void
 	 */
-	public function update_js( $id = 'wc-apa-update-vals' ) {
+	public function update_js( $id ) {
+
+		if ( '' === $id ) {
+			$id = 'wc-apa-update-vals';
+		}
+
 		$checkout_session_config = WC_Amazon_Payments_Advanced_API::get_create_checkout_session_config();
 
 		$data = array(
 			'action'                         => $this->get_current_cart_action(),
 			'create_checkout_session_config' => $checkout_session_config,
 			'create_checkout_session_hash'   => wp_hash( $checkout_session_config['payloadJSON'] ),
+			'estimated_order_amount'         => $this->get_estimated_order_amount(),
 		);
 		?>
 		<script type="text/template" id="<?php echo esc_attr( $id ); ?>" data-value="<?php echo esc_attr( wp_json_encode( $data ) ); ?>"></script>
@@ -2507,6 +2514,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			return true;
 		}
 
+		// To capture the cart redirect on update cart actions.
+		if ( isset( $_SERVER['HTTP_REFERER'] ) && $_SERVER['HTTP_REFERER'] === wc_get_cart_url() ) {
+			return true;
+		}
+
 		return false;
 	}
 
@@ -2884,5 +2896,24 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		}
 
 		return $payload;
+	}
+
+	/**
+	 * Get the estimated order amount from the cart totals.
+	 *
+	 * @return array
+	 */
+	private static function get_estimated_order_amount() {
+
+		if ( is_null( WC()->cart ) ) {
+			return array();
+		}
+
+		return wp_json_encode(
+			array(
+				'amount'       => WC()->cart->get_total( 'amount' ),
+				'currencyCode' => get_woocommerce_currency(),
+			)
+		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Add a product to the cart.
2. Make sure that amazon pay button is active.
3. Try to update the cart items (change the quantity of the added item, add a new item or remove the existing one)
4. The following message is logged on browser's console (sandbox mode): Estimated order amount for sandbox is {"amount":"XXX","currencyCode":"XXX"}

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Add - Estimated order amount setting on pay button.