### PR TITLE
Use wp_get_referer instead of $_SERVER['HTTP_REFERER']

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2565,10 +2565,10 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		/**
 		 * To capture the cart redirect on update cart actions.
-		 * Considered wp_get_referer instead, but it wouldn't produce the expected
-		 * results when Update cart is clicked on the cart page.
+		 *
+		 * wp_get_referer will return false when the request comes from the same page.
 		 */
-		if ( isset( $_SERVER['HTTP_REFERER'] ) && wc_get_cart_url() === $_SERVER['HTTP_REFERER'] ) {
+		if ( false === wp_get_referer() ) {
 			return true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes the approach of confirming if the active Request is an AJAX request. 
@see https://github.com/woocommerce/woocommerce-gateway-amazon-pay/pull/213#discussion_r990416190

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

