### PR TITLE
Fixes error for merchants not yet migrated to v2 amazon keys

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,7 @@ docker-compose.yml export-ignore
 docs/DOCKER.md export-ignore
 wordpress_org_assets export-ignore
 src export-ignore
+.vscode export-ignore
+node_modules export-ignore
+.prettierrc.js export-ignore
+woocommerce-gateway-amazon-pay.zip export-ignore

--- a/includes/class-wc-amazon-payments-advanced-compat.php
+++ b/includes/class-wc-amazon-payments-advanced-compat.php
@@ -79,7 +79,7 @@ class WC_Amazon_Payments_Advanced_Compat {
 	 * @return void
 	 */
 	public function load_block_compatibility() {
-		if ( class_exists( 'WC_Gateway_Amazon_Payments_Advanced' ) && class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) && file_exists( __DIR__ . '/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compatibility.php' ) ) {
+		if ( WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() && class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) && file_exists( __DIR__ . '/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compatibility.php' ) ) {
 			require_once __DIR__ . '/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compatibility.php';
 			add_action( 'woocommerce_blocks_payment_method_type_registration', array( WC_Amazon_Payments_Advanced_Block_Compatibility::class, 'init' ) );
 		}

--- a/includes/class-wc-amazon-payments-advanced-compat.php
+++ b/includes/class-wc-amazon-payments-advanced-compat.php
@@ -79,7 +79,7 @@ class WC_Amazon_Payments_Advanced_Compat {
 	 * @return void
 	 */
 	public function load_block_compatibility() {
-		if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) && file_exists( __DIR__ . '/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compatibility.php' ) ) {
+		if ( class_exists( 'WC_Gateway_Amazon_Payments_Advanced' ) && class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) && file_exists( __DIR__ . '/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compatibility.php' ) ) {
 			require_once __DIR__ . '/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compatibility.php';
 			add_action( 'woocommerce_blocks_payment_method_type_registration', array( WC_Amazon_Payments_Advanced_Block_Compatibility::class, 'init' ) );
 		}

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php
@@ -30,7 +30,7 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Express extends WC_Amazon_Payment
 	 * @return boolean
 	 */
 	public function is_active() {
-		return wc_apa()->should_express_be_loaded() && wc_apa()->get_gateway()->is_available();;
+		return wc_apa()->should_express_be_loaded() && wc_apa()->get_gateway()->is_available();
 	}
 
 	/**

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php
@@ -30,7 +30,7 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Express extends WC_Amazon_Payment
 	 * @return boolean
 	 */
 	public function is_active() {
-		return wc_apa()->get_gateway()->is_available();
+		return wc_apa()->should_express_be_loaded() && wc_apa()->get_gateway()->is_available();;
 	}
 
 	/**

--- a/src/utils.js
+++ b/src/utils.js
@@ -115,5 +115,5 @@ export const getCheckOutFieldsLabel = ( field, billingOrShipping ) => {
  * @returns {bool}
  */
 export const amazonPayCanMakePayment = ( { cartTotals }, { allowedCurrencies } ) => {
-	return allowedCurrencies ? allowedCurrencies.includes( cartTotals.currency_code ) : true;
+	return allowedCurrencies && allowedCurrencies.length > 0 ? allowedCurrencies.includes( cartTotals.currency_code ) : true;
 };

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -264,8 +264,15 @@ class WC_Amazon_Payments_Advanced {
 	public function add_gateway( $methods ) {
 		$methods[] = $this->gateway;
 
-		// Load express gateway only if WooCommerce blocks is installed and activated.
-		if ( class_exists( 'Automattic\WooCommerce\Blocks\Package' ) ) {
+		/**
+		 * Load express gateway only if
+		 *
+		 * 1) Merchant has migrated to V2 of the Amazon API and as a result
+		 *    he is using the WC_Gateway_Amazon_Payments_Advanced class as the
+		 *    Amazon Pay main Gateway.
+		 * 2) WooCommerce blocks is installed and activated
+		 */
+		if ( class_exists( 'WC_Gateway_Amazon_Payments_Advanced' ) && class_exists( 'Automattic\WooCommerce\Blocks\Package' ) ) {
 			require_once $this->includes_path . 'class-wc-gateway-amazon-payments-advanced-express.php';
 			$this->express_gateway = new WC_Gateway_Amazon_Payments_Advanced_Express();
 			$methods[]             = $this->express_gateway;

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -552,7 +552,7 @@ class WC_Amazon_Payments_Advanced {
 	 * @return boolean
 	 */
 	public function should_express_be_loaded() {
-		return class_exists( 'WC_Gateway_Amazon_Payments_Advanced' ) && class_exists( 'Automattic\WooCommerce\Blocks\Package' );
+		return WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() && class_exists( 'Automattic\WooCommerce\Blocks\Package' );
 	}
 }
 

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -264,15 +264,7 @@ class WC_Amazon_Payments_Advanced {
 	public function add_gateway( $methods ) {
 		$methods[] = $this->gateway;
 
-		/**
-		 * Load express gateway only if
-		 *
-		 * 1) Merchant has migrated to V2 of the Amazon API and as a result
-		 *    he is using the WC_Gateway_Amazon_Payments_Advanced class as the
-		 *    Amazon Pay main Gateway.
-		 * 2) WooCommerce blocks is installed and activated
-		 */
-		if ( class_exists( 'WC_Gateway_Amazon_Payments_Advanced' ) && class_exists( 'Automattic\WooCommerce\Blocks\Package' ) ) {
+		if ( $this->should_express_be_loaded() ) {
 			require_once $this->includes_path . 'class-wc-gateway-amazon-payments-advanced-express.php';
 			$this->express_gateway = new WC_Gateway_Amazon_Payments_Advanced_Express();
 			$methods[]             = $this->express_gateway;
@@ -545,6 +537,22 @@ class WC_Amazon_Payments_Advanced {
 	 */
 	public function get_express_gateway() {
 		return $this->express_gateway;
+	}
+
+	/**
+	 * Checks whether Express Gateway should be loaded or not.
+	 *
+	 * Express gateway should only be loaded if:
+	 *
+	 * 1) Merchant has migrated to V2 of the Amazon API and as a result
+	 *    he is using the WC_Gateway_Amazon_Payments_Advanced class as the
+	 *    Amazon Pay main Gateway.
+	 * 2) WooCommerce blocks is installed and activated
+	 *
+	 * @return boolean
+	 */
+	public function should_express_be_loaded() {
+		return class_exists( 'WC_Gateway_Amazon_Payments_Advanced' ) && class_exists( 'Automattic\WooCommerce\Blocks\Package' );
 	}
 }
 

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -264,7 +264,15 @@ class WC_Amazon_Payments_Advanced {
 	public function add_gateway( $methods ) {
 		$methods[] = $this->gateway;
 
-		if ( $this->should_express_be_loaded() ) {
+		/**
+		 * Method should_express_be_loaded can be used early before actually loading the class WC_Gateway_Amazon_Payments_Advanced
+		 *
+		 * @see includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php method is_active()
+		 *
+		 * Here though the class WC_Gateway_Amazon_Payments_Advanced should already be loaded as long as the merchant is
+		 * using v2 keys. so we make sure it can be loaded by checking the class's existence.
+		 */
+		if ( $this->should_express_be_loaded() && class_exists( 'WC_Gateway_Amazon_Payments_Advanced' ) ) {
 			require_once $this->includes_path . 'class-wc-gateway-amazon-payments-advanced-express.php';
 			$this->express_gateway = new WC_Gateway_Amazon_Payments_Advanced_Express();
 			$methods[]             = $this->express_gateway;

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -264,15 +264,7 @@ class WC_Amazon_Payments_Advanced {
 	public function add_gateway( $methods ) {
 		$methods[] = $this->gateway;
 
-		/**
-		 * Method should_express_be_loaded can be used early before actually loading the class WC_Gateway_Amazon_Payments_Advanced
-		 *
-		 * @see includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php method is_active()
-		 *
-		 * Here though the class WC_Gateway_Amazon_Payments_Advanced should already be loaded as long as the merchant is
-		 * using v2 keys. so we make sure it can be loaded by checking the class's existence.
-		 */
-		if ( $this->should_express_be_loaded() && class_exists( 'WC_Gateway_Amazon_Payments_Advanced' ) ) {
+		if ( $this->should_express_be_loaded() ) {
 			require_once $this->includes_path . 'class-wc-gateway-amazon-payments-advanced-express.php';
 			$this->express_gateway = new WC_Gateway_Amazon_Payments_Advanced_Express();
 			$methods[]             = $this->express_gateway;
@@ -555,12 +547,13 @@ class WC_Amazon_Payments_Advanced {
 	 * 1) Merchant has migrated to V2 of the Amazon API and as a result
 	 *    he is using the WC_Gateway_Amazon_Payments_Advanced class as the
 	 *    Amazon Pay main Gateway.
-	 * 2) WooCommerce blocks is installed and activated
+	 * 2) Class WC_Gateway_Amazon_Payments_Advanced has been loaded.
+	 * 3) WooCommerce blocks is installed and activated
 	 *
 	 * @return boolean
 	 */
 	public function should_express_be_loaded() {
-		return WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() && class_exists( 'Automattic\WooCommerce\Blocks\Package' );
+		return WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() && class_exists( 'WC_Gateway_Amazon_Payments_Advanced' ) && class_exists( 'Automattic\WooCommerce\Blocks\Package' );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We won't load the Express Gateway for merchants not yet migrated to V2 Amazon Keys and the FE is going to reflect that.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #225 .

### How to test the changes in this Pull Request:

1. While using V2 keys of Amazon and WooCommerce Blocks, Amazon Express should appear in the cart and checkout blocks.
2. While using V1 keys of Amazon and WooCommerce Blocks, Amazon Express shoud not appear in the cart and checkout blocks.
3. While using V1 keys of Amazon and WooCommerce Blocks, classic gateway should not be present.
4. While using V1 keys of Amazon and WooCommerce Blocks, no error should be thrown.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error for merchants still using V1 Amazon Keys
