### PR TITLE
FrontEnd allowed currencies take insto consideration status of compatible multi currency plugin

### DIFF
--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-abstract.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-abstract.php
@@ -116,7 +116,6 @@ abstract class WC_Amazon_Payments_Advanced_Block_Compat_Abstract extends Abstrac
 			return false;
 		}
 
-		$allowed_currencies = WC_Amazon_Payments_Advanced_API::get_selected_currencies();
-		return ! empty( $allowed_currencies ) && is_array( $allowed_currencies ) ? array_values( $allowed_currencies ) : false;
+		return array_values( WC_Amazon_Payments_Advanced_API::get_selected_currencies() );
 	}
 }

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-abstract.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-abstract.php
@@ -105,4 +105,18 @@ abstract class WC_Amazon_Payments_Advanced_Block_Compat_Abstract extends Abstrac
 		}
 		return array();
 	}
+
+	/**
+	 * Returns supported currencies if multi currency is enabled.
+	 *
+	 * @return array|false
+	 */
+	protected function get_allowed_currencies() {
+		if ( ! WC_Amazon_Payments_Advanced_Multi_Currency::is_active() ) {
+			return false;
+		}
+
+		$allowed_currencies = WC_Amazon_Payments_Advanced_API::get_selected_currencies();
+		return ! empty( $allowed_currencies ) && is_array( $allowed_currencies ) ? array_values( $allowed_currencies ) : false;
+	}
 }

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
@@ -49,7 +49,7 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 			'supports'            => $this->get_supported_features(),
 			'amazonPayPreviewUrl' => esc_url( wc_apa()->plugin_url . '/assets/images/amazon-pay-preview.png' ),
 			'action'              => wc_apa()->get_gateway()->get_current_cart_action(),
-			'allowedCurrencies'   => WC_Amazon_Payments_Advanced_API::get_selected_currencies(),
+			'allowedCurrencies'   => $this->get_allowed_currencies(),
 		);
 	}
 

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-express.php
@@ -56,7 +56,7 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Express extends WC_Amazon_Payment
 				'selectedPaymentMethod' => esc_html( $wc_apa_gateway->get_selected_payment_label( $checkout_session ) ),
 				'hasPaymentPreferences' => $wc_apa_gateway->has_payment_preferences( $checkout_session ),
 				'allOtherGateways'      => $this->gateways_to_unset_on_fe(),
-				'allowedCurrencies'     => WC_Amazon_Payments_Advanced_API::get_selected_currencies(),
+				'allowedCurrencies'     => $this->get_allowed_currencies(),
 				'amazonPayPreviewUrl'   => esc_url( wc_apa()->plugin_url . '/assets/images/amazon-pay-preview.png' ),
 				'amazonAddress'         => array(
 					'amazonBilling'  => $checkout_session && ! is_wp_error( $checkout_session ) && ! empty( $checkout_session->billingAddress ) ? WC_Amazon_Payments_Advanced_API::format_address( $checkout_session->billingAddress ) : null, // phpcs:ignore WordPress.NamingConventions


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

FE provided allowed currencies to blocks should take into consideration if there is a multi currency plugin enabled. Altered PHP to return false instead of an empty array when there should be the selected currency available when no multi currency plugin is present.

**Helpfull** to see src/utils.js, function amazonPayCanMakePayment to understand easier the concept of this PR. If a compatible multi currency plugin used to be active and compatible currencies have been saved in the DB, method `WC_Amazon_Payments_Advanced_API::get_selected_currencies()` returns the saved compatible currencies present in the DB without considering if there is still an active and compatible multi currency plugin.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Amazon Pay Express should be enabled when no compatible multicurrency plugin is present when using blocks.
2. If a mutli currency compatible plugin is disabled, FE allowed currencies should be just like if that plugin was never part of the installation when using blocks.
3. If a disallowed currency is selected amazon pay Express should be unavailable when using blocks.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - FrontEnd Allowed Currencies should depend on compatible 's Multi currency plugin active status.