### PR TITLE
Tweak/plugin compat updates

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -935,8 +935,12 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		}
 
 		$checkout_session = $this->get_checkout_session();
-		$buyer_id         = $checkout_session->buyer->buyerId;
-		$buyer_email      = $checkout_session->buyer->email;
+		$buyer_id         = ! empty( $checkout_session->buyer->buyerId ) ? $checkout_session->buyer->buyerId : null;
+		$buyer_email      = ! empty( $checkout_session->buyer->email ) ? $checkout_session->buyer->email : null;
+
+		if ( ! $buyer_id || ! $buyer_email ) {
+			return; // We shouldn't be here anyways.
+		}
 
 		$buyer_user_id = $this->get_customer_id_from_buyer( $buyer_id );
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic, woothemes, akeda, jeffstieler, mikejolley, bor0, claudiosanches, royho, jamesrrodger, laurendavissmith001, dwainm, danreylop
 Tags: woocommerce, amazon, checkout, payments, e-commerce, ecommerce
 Requires at least: 5.5
-Tested up to: 6.0
+Tested up to: 6.2
 Stable tag: 2.4.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/src/js/_utils.js
+++ b/src/js/_utils.js
@@ -100,10 +100,14 @@ export const AmazonPayPreview = ( { settings, ...props } ) => {
  *
  * @param {string} field The field's name to retrieve the label for.
  * @param {string} billingOrShipping If the field is for billing or shipping details.
- * @returns {string} The field's label.
+ * @returns {string}|{bool} The field's label or false if the field is not present.
  */
 export const getCheckOutFieldsLabel = ( field, billingOrShipping ) => {
 	const elem = document.getElementById( billingOrShipping + '-' + field );
+	if ( ! elem ) {
+		return false;
+	}
+
 	return elem && elem.getAttribute( 'aria-label' ) ? elem.getAttribute( 'aria-label' ) : '';
 };
 

--- a/src/js/payments-methods/express/_payment-methods.js
+++ b/src/js/payments-methods/express/_payment-methods.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import React from 'react';
 
@@ -61,7 +61,7 @@ const AmazonPayInfo = ( props ) => {
             
                     // Field present in the form but value mismatch. Return error.
                     return {
-                        errorMessage: __( 'We were expecting "', 'woocommerce-gateway-amazon-payments-advanced' ) + amazonShipping[ shippingField ] + __( '" but we received "', 'woocommerce-gateway-amazon-payments-advanced' ) + shippingAddress[ shippingField ] + __( '" instead for the Shipping field "', 'woocommerce-gateway-amazon-payments-advanced' ) + checkoutFieldLabel + __( '". Please make any changes to your Shipping details through Amazon.', 'woocommerce-gateway-amazon-payments-advanced' )
+                        errorMessage: sprintf( __( 'We were expecting "%1$s" but we received "%2$s" instead for the Shipping field "%3$s". Please make any changes to your Shipping details through Amazon."', 'woocommerce-gateway-amazon-payments-advanced' ), amazonShipping[ shippingField ], shippingAddress[ shippingField ], checkoutFieldLabel )
                     };
                 }
 

--- a/src/js/payments-methods/express/_payment-methods.js
+++ b/src/js/payments-methods/express/_payment-methods.js
@@ -32,7 +32,7 @@ const ChangePayment = () => {
 };
  
 /**
- * Returns a react component and also sets an observer for the onCheckoutValidationBeforeProcessing event.
+ * Returns a react component and also sets an observer for the onCheckoutValidation event.
  *
  * @param {object} props
  * @returns React component
@@ -45,14 +45,24 @@ const AmazonPayInfo = ( props ) => {
     const { amazonBilling, amazonShipping } = settings.amazonAddress;
 
     useEffect( () => {
-        const unsubscribe = props.eventRegistration.onCheckoutValidationBeforeProcessing(
+        const unsubscribe = props.eventRegistration.onCheckoutValidation(
             async () => {
                 for ( const shippingField in amazonShipping ) {
-                    if ( amazonShipping[ shippingField ] !== shippingAddress[ shippingField ] ) {
-                        return {
-                            errorMessage: __( 'We were expecting "', 'woocommerce-gateway-amazon-payments-advanced' ) + amazonShipping[ shippingField ] + __( '" but we received "', 'woocommerce-gateway-amazon-payments-advanced' ) + shippingAddress[ shippingField ] + __( '" instead for the Shipping field "', 'woocommerce-gateway-amazon-payments-advanced' ) + getCheckOutFieldsLabel( shippingField, 'shipping' ) + __( '". Please make any changes to your Shipping details through Amazon.', 'woocommerce-gateway-amazon-payments-advanced' )
-                        };
+                     // Values are the same as expected. Bail.
+                    if (amazonShipping[ shippingField ] === shippingAddress[ shippingField ]) {
+                        continue;
                     }
+            
+                    const checkoutFieldLabel = getCheckOutFieldsLabel( shippingField, 'shipping' );
+                    // Field not present in the form, as a result value can't be supplied. Bail.
+                    if ( false === checkoutFieldLabel ) {
+                        continue;
+                    }
+            
+                    // Field present in the form but value mismatch. Return error.
+                    return {
+                        errorMessage: __( 'We were expecting "', 'woocommerce-gateway-amazon-payments-advanced' ) + amazonShipping[ shippingField ] + __( '" but we received "', 'woocommerce-gateway-amazon-payments-advanced' ) + shippingAddress[ shippingField ] + __( '" instead for the Shipping field "', 'woocommerce-gateway-amazon-payments-advanced' ) + checkoutFieldLabel + __( '". Please make any changes to your Shipping details through Amazon.', 'woocommerce-gateway-amazon-payments-advanced' )
+                    };
                 }
 
                 return true;
@@ -60,7 +70,7 @@ const AmazonPayInfo = ( props ) => {
         );
         return () => unsubscribe();
     }, [
-        props.eventRegistration.onCheckoutValidationBeforeProcessing,
+        props.eventRegistration.onCheckoutValidation,
         billingData,
         shippingAddress,
         amazonBilling,

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -8,8 +8,8 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce-gateway-amazon-payments-advanced
  * Domain Path: /languages/
- * Tested up to: 6.0
- * WC tested up to: 7.0
+ * Tested up to: 6.2
+ * WC tested up to: 7.8
  * WC requires at least: 4.0
  *
  * Copyright: © 2023 WooCommerce


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Updates plugin compatibility headers with WP and WC.
Fixes a php warning which could occur on failed transactions.
Updates woo blocks checkout event from `onCheckoutValidationBeforeProcessing` to `onCheckoutValidation`. There was a deprecation notice while testing using the woocommerce blocks feature plugin.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

1. The woocommerce blocks checkout should be functional after the deprecation update
2. The php warning should not appear after failed transactions

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Update WP and WC tested up to
> Fix - PHP warning on failed transactions
> Fix - WooCommerce Blocks compatibility
