### PR TITLE
Set Amazon Pay as the payment method of a subscription when saving the payment meta

### DIFF
--- a/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-subscriptions.php
@@ -474,6 +474,7 @@ class WC_Gateway_Amazon_Payments_Advanced_Subscriptions {
 
 				$subscription->update_meta_data( $key, $value );
 			}
+			$subscription->set_payment_method( wc_apa()->get_gateway()->id );
 			$subscription->save();
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In WooCommerce Subscriptions we have a setting that allows customers to purchase $0 subscription products (i.e. subscriptions that have a trial period) without entering a payment method on the checkout: 
![image](https://github.com/woocommerce/woocommerce-gateway-amazon-pay/assets/2275145/7e9b58ea-aac9-43df-97e1-b5c3e9d9c27f)

After the free trial ends, when the customer pays for the first renewal order with Amazon Pay, the new payment method is not set on the subscription resulting in the subscription remaining as requiring manual renewal, instead of automatically renewing with Amazon Pay.

I recorded my screen to showcase the issue:

https://github.com/woocommerce/woocommerce-gateway-amazon-pay/assets/2275145/3c849770-2ed9-4d83-a175-f68fad375987

This PR fixes this issue by making sure Amazon Pay is also set as the payment method of the subscription when also copying over the payment method meta from the order.

Closes #283

### How to test the changes in this Pull Request:

1. Install and activate the latest WooCommerce Subscriptions extension
2. Enable the $0 checkout setting in **WooCommerce > Settings >Subscriptions**
3. Create a subscription product with a 7-day free trial
4. Purchase the subscription with no payment method.
5. You will see the trial and next payment date. The subscription will be in "manual payment" mode which is expected.
6. Manually trigger the subscription renewal using the "Process renewal" subscription action:
![image](https://github.com/woocommerce/woocommerce-gateway-amazon-pay/assets/2275145/500c16c4-341d-4642-911b-eaef8e6463ba)
7. Now pay for the new pending renewal order from My Account page and complete the payment with Amazon Pay
9. Check the subscription on the My Account page and confirm the payment method is set to Amazon Pay: 
![image](https://github.com/woocommerce/woocommerce-gateway-amazon-pay/assets/2275145/0af16578-742b-41e3-b236-c606c8185983)
10. Process another renewal and confirm Amazon pay processing the renewal automatically.

### Other information:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

