### PR TITLE
[dev] Pin Github actions to full-commit SHA

### DIFF
--- a/.github/workflows/php-unit-on-pr.yml
+++ b/.github/workflows/php-unit-on-pr.yml
@@ -69,10 +69,6 @@ jobs:
         shell: bash
         run: npm ci
 
-      # Setup jq
-      - name: 'Setup jq'
-        uses: dcarbone/install-jq-action@v1.0.1
-
       # Prepare test environment
       - name: Prepare test environment
         run: |


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the P75Izm-1JH-p2 standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes [QAO-40](https://linear.app/a8c/issue/QAO-40/pin-github-actions-to-full-commit-shas-for-immutability)
Contributes to [QAO-23](https://linear.app/a8c/issue/QAO-23)

Pins Github actions to full commit SHAs as immutable references.
Skipped all official GitHub actions.  
No version update for setup-php action - used the latest commit in the tag that was already used.
Bumped one of the usages of `actions/cache` from v1 to v4 to fix the workflow that was failing because v1 is deprecated.
Removes `dcarbone/install-jq-action` action - the ubuntu runner image already comes with jq preinstalled

### How to test the changes in this Pull Request:

PHP unit tests workflow should pass in CI

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

CI workflow updates