### PR TITLE
Release/2.6.2

### DIFF
--- a/.github/workflows/php-unit-on-pr.yml
+++ b/.github/workflows/php-unit-on-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.3, 7.4, 8.0, 8.1 ]
+        php: [ 7.4, 8.0, 8.1 ]
     services:
       database:
         image: mysql:5.6

--- a/.github/workflows/php-unit-on-pr.yml
+++ b/.github/workflows/php-unit-on-pr.yml
@@ -30,6 +30,11 @@ jobs:
           tools: composer
           coverage: none
 
+      # Check Composer Version
+      - name: Check Composer Version
+        shell: bash
+        run: composer --version
+
       # Use node version from .nvmrc
       - name: Setup NodeJS
         uses: actions/setup-node@v4

--- a/.github/workflows/php-unit-on-pr.yml
+++ b/.github/workflows/php-unit-on-pr.yml
@@ -30,11 +30,6 @@ jobs:
           tools: composer
           coverage: none
 
-      # Composer setup
-      - name: Setup Composer
-        shell: bash
-        run: composer self-update 2.0.6
-
       # Use node version from .nvmrc
       - name: Setup NodeJS
         uses: actions/setup-node@v4

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Amazon Pay Changelog ***
 
-= 2.6.2 - 2026-07-14 =
+= 2.6.2 - 2026-xx-xx =
 
 * Fix - Fatal error in the IPN handler (v2) when the related order could not be retrieved.
 * Fix - Amazon Pay incorrectly requiring the phone number for all payment methods.

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,8 @@
 * Fix - PHP warnings and errors.
 * Dev - Removed pinned Composer version to address a potential security vulnerability.
 * Dev - Bumped required PHP version to 7.4.
+* Dev - Bumped tested up to WordPress v7.0.1.
+* Dev - Bumped tested up to WooCommerce v10.8.1.
 
 = 2.6.1 - 2026-01-21 =
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,14 @@
 *** Amazon Pay Changelog ***
 
+= 2.6.2 - 2026-07-14 =
+
+* Fix - Fatal error in the IPN handler (v2) when the related order could not be retrieved.
+* Fix - Amazon Pay incorrectly requiring the phone number for all payment methods.
+* Fix - Prevent duplicate charges when paying with Amazon Pay on Classic Checkout.
+* Fix - PHP warnings and errors.
+* Dev - Removed pinned Composer version to address a potential security vulnerability.
+* Dev - Bumped required PHP version to 7.4.
+
 = 2.6.1 - 2026-01-21 =
 
 * Add - Admin Order note for cancellations and payment failures.

--- a/composer.lock
+++ b/composer.lock
@@ -7798,5 +7798,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/includes/class-wc-amazon-payments-advanced-api.php
+++ b/includes/class-wc-amazon-payments-advanced-api.php
@@ -439,7 +439,7 @@ class WC_Amazon_Payments_Advanced_API extends WC_Amazon_Payments_Advanced_API_Ab
 	 * Get Checkout Session Data.
 	 *
 	 * @param  string $checkout_session_id Checkout Session Id.
-	 * @return object Checkout Session from the API
+	 * @return object|WP_Error Checkout Session from the API
 	 */
 	public static function get_checkout_session_data( $checkout_session_id ) {
 		$client = self::get_client();

--- a/includes/class-wc-amazon-payments-advanced-ipn-handler.php
+++ b/includes/class-wc-amazon-payments-advanced-ipn-handler.php
@@ -467,6 +467,9 @@ class WC_Amazon_Payments_Advanced_IPN_Handler extends WC_Amazon_Payments_Advance
 		}
 
 		$order    = apply_filters( 'woocommerce_amazon_pa_ipn_notification_order', $order, $notification );
+		if ( ! is_a( $order, WC_Order::class ) ) {
+			throw new Exception( "Order not found for order ID $order_id" );
+		}
 		$order_id = $order->get_id(); // Refresh variable, in case it changed.
 
 		if ( 'amazon_payments_advanced' !== $order->get_payment_method() ) {

--- a/includes/class-wc-amazon-payments-advanced-merchant-onboarding-handler.php
+++ b/includes/class-wc-amazon-payments-advanced-merchant-onboarding-handler.php
@@ -191,31 +191,40 @@ class WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler {
 	 * @return mixed
 	 * @throws Exception On Errors.
 	 */
-	protected function generate_keys( $public = false ) {
+	protected function generate_keys( $public = false, $reset = false ) {
 
 		if ( ! function_exists( 'openssl_pkey_new' ) || ! function_exists( 'openssl_verify' ) ) {
 			throw new Exception( esc_html__( 'OpenSSL extension is not available in your server.', 'woocommerce-gateway-amazon-payments-advanced' ) );
 		}
-		$keys = openssl_pkey_new(
-			array(
-				'digest_alg'       => self::DIGEST_ALG,
-				'private_key_bits' => self::PRIVATE_KEY_BITS,
-				'private_key_type' => self::PRIVATE_KEY_TYPE,
-			)
-		);
-		if ( false === $keys ) {
-			throw new Exception( esc_html__( 'Failed to generate OpenSSL key pair.', 'woocommerce-gateway-amazon-payments-advanced' ) );
-		}
-
-		$public_key = openssl_pkey_get_details( $keys );
-		openssl_pkey_export( $keys, $private_key );
 
 		$temps = $this->get_temp_private_keys();
 
-		$temps[] = $private_key;
-		update_option( self::KEYS_OPTION_TEMP_PRIVATE_KEYS, $temps );
+		if ( ! $reset && ! empty( $temps ) ) {
+			$private_key = end( $temps );
+		} else {
+			$keys = openssl_pkey_new(
+				array(
+					'digest_alg'       => self::DIGEST_ALG,
+					'private_key_bits' => self::PRIVATE_KEY_BITS,
+					'private_key_type' => self::PRIVATE_KEY_TYPE,
+				)
+			);
+			if ( false === $keys ) {
+				throw new Exception( esc_html__( 'Failed to generate OpenSSL key pair.', 'woocommerce-gateway-amazon-payments-advanced' ) );
+			}
 
-		return ( $public ) ? $public_key['key'] : $private_key;
+			openssl_pkey_export( $keys, $private_key );
+
+			$temps[] = $private_key;
+			update_option( self::KEYS_OPTION_TEMP_PRIVATE_KEYS, $temps, 'no' );
+		}
+
+		if ( ! $public ) {
+			return $private_key;
+		}
+
+		$details = openssl_pkey_get_details( openssl_pkey_get_private( $private_key ) );
+		return $details['key'];
 	}
 
 	/**
@@ -223,6 +232,7 @@ class WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler {
 	 */
 	public static function destroy_keys() {
 		delete_option( self::KEYS_OPTION_PRIVATE_KEY );
+		delete_option( self::KEYS_OPTION_TEMP_PRIVATE_KEYS );
 	}
 
 	/**
@@ -289,7 +299,7 @@ class WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler {
 		$private_key = get_option( self::KEYS_OPTION_PRIVATE_KEY, false );
 
 		if ( ( ! $private_key ) || $reset ) {
-			$private_key = $this->generate_keys( false );
+			$private_key = $this->generate_keys( false, $reset );
 		}
 
 		return $private_key;
@@ -334,7 +344,7 @@ class WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler {
 	public static function get_migration_status() {
 		$status      = get_option( 'amazon_api_version' );
 		$old_install = version_compare( get_option( 'woocommerce_amazon_payments_new_install' ), '2.0.0', '>=' );
-		return 'V2' === $status || $old_install ? true : false;
+		return 'V2' === $status || (bool) $old_install;
 	}
 
 	/**
@@ -342,6 +352,7 @@ class WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler {
 	 */
 	public static function update_migration_status() {
 		update_option( 'amazon_api_version', 'V2' );
+		delete_option( self::KEYS_OPTION_TEMP_PRIVATE_KEYS );
 	}
 
 	/**

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -174,6 +174,13 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	protected $enable_login_app;
 
 	/**
+	 * Flag to suppress the phone required filter during base value lookup.
+	 *
+	 * @var bool
+	 */
+	private static $suppress_phone_filter = false;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -1058,6 +1065,10 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 	 */
 	public function maybe_flag_phone_number_as_required( $option_value ) {
 
+		if ( self::$suppress_phone_filter ) {
+			return $option_value;
+		}
+
 		if ( ! $this->is_available() ) {
 			return $option_value;
 		}
@@ -1091,16 +1102,10 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
      * @return bool
      */
     public function phone_number_is_required_base() {
-		$filter_callback  = array( $this, 'maybe_flag_phone_number_as_required' );
-		$has_filter = has_filter( 'option_woocommerce_checkout_phone_field', $filter_callback );
-		if ( $has_filter ) {
-			remove_filter( 'option_woocommerce_checkout_phone_field', $filter_callback );
-		}
+		self::$suppress_phone_filter = true;
 		/** @see \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::get_core_fields */
 		$base_phone_required = 'required' === CartCheckoutUtils::get_phone_field_visibility();
-		if ( $has_filter ) {
-			add_filter('option_woocommerce_checkout_phone_field', $filter_callback);
-		}
+		self::$suppress_phone_filter = false;
 
         return $base_phone_required;
     }

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -4,6 +4,7 @@
  *
  * @package WC_Gateway_Amazon_Pay
  */
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 
 /**
  * WC_Gateway_Amazon_Payments_Advanced_Abstract
@@ -1087,6 +1088,25 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
      */
     public function phone_number_is_required() {
         return ( ! empty( WC()->cart ) ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping();
+    }
+
+    /**
+     * Indicates whether the phone was required without taking Amazon Pay into account
+     * @return bool
+     */
+    public function phone_number_is_required_base() {
+		$filter_callback  = array( $this, 'maybe_flag_phone_number_as_required' );
+		$has_filter = has_filter( 'option_woocommerce_checkout_phone_field', $filter_callback );
+		if ( $has_filter ) {
+			remove_filter( 'option_woocommerce_checkout_phone_field', $filter_callback );
+		}
+		/** @see \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::get_core_fields */
+		$base_phone_required = 'required' === CartCheckoutUtils::get_phone_field_visibility();
+		if ( $has_filter ) {
+			add_filter('option_woocommerce_checkout_phone_field', $filter_callback);
+		}
+
+        return $base_phone_required;
     }
 
 	/**

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -854,7 +854,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 
 				$finfo = new finfo( FILEINFO_MIME_TYPE );
 				$ext   = $finfo->file( $pem_file['tmp_name'] );
-				if ( 'text/plain' === $ext && isset( $pem_file['tmp_name'] ) ) {
+				if ( in_array( $ext, array( 'text/plain', 'text/x-ssh-private-key' ), true ) && isset( $pem_file['tmp_name'] ) ) {
 					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 					$private_key = file_get_contents( $pem_file['tmp_name'] );
 					$this->save_private_key( $private_key );

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -341,10 +341,16 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 		$redirect_url           = $this->get_amazon_payments_checkout_url();
 		$valid                  = isset( $this->settings['amazon_keys_setup_and_validated'] ) ? $this->settings['amazon_keys_setup_and_validated'] : false;
 
-		$button_desc = __( 'Register for a new Amazon Pay merchant account, or sign in with your existing Amazon Pay Seller Central credentials to complete the plugin upgrade and configuration', 'woocommerce-gateway-amazon-payments-advanced' );
-		$button_btn  = '<a class="register_now button-primary">' . __( 'Connect to Amazon Pay', 'woocommerce-gateway-amazon-payments-advanced' ) . '</a>';
+		$button_desc = __( 'Register for a new Amazon Pay merchant account, or sign in with your existing Amazon Pay Seller Central credentials to complete the plugin upgrade and configuration.', 'woocommerce-gateway-amazon-payments-advanced' );
+		$button_note = '<strong>' . __( 'Note for existing Amazon Pay accounts:', 'woocommerce-gateway-amazon-payments-advanced' ) . '</strong> ' . sprintf(
+			/* translators: %s: manual key retrieval documentation URL. */
+			__( 'Due to a recent change in Amazon\'s onboarding flow, the automated connection process may not complete successfully for existing accounts. If the process appears to hang, <a href="%s" target="_blank">manually retrieve your keys from Seller Central</a> and paste them using the manual credentials entry below.', 'woocommerce-gateway-amazon-payments-advanced' ),
+			'https://woocommerce.com/document/amazon-payments-advanced/#section-5.1'
+		);
+		$button_btn = '<a class="register_now button-primary">' . __( 'Connect to Amazon Pay', 'woocommerce-gateway-amazon-payments-advanced' ) . '</a>';
 		if ( $this->private_key ) {
-			$button_desc = __( 'In order to connect to a different account you need to disconect first, this will delete current Account Settings, you will need to go throught all the configuration process again', 'woocommerce-gateway-amazon-payments-advanced' );
+			$button_desc = __( 'In order to connect to a different account you need to disconnect first, this will delete current Account Settings, you will need to go through all the configuration process again', 'woocommerce-gateway-amazon-payments-advanced' );
+			$button_note = '';
 			$button_btn  = '<a class="delete-settings button-primary">' . __( 'Disconnect Amazon Pay', 'woocommerce-gateway-amazon-payments-advanced' ) . '</a>';
 		}
 		if ( ! WC_Amazon_Payments_Advanced_Merchant_Onboarding_Handler::get_migration_status() ) {
@@ -372,7 +378,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 			'register_now'                => array(
 				'title'       => __( 'Connect your Amazon Pay merchant account', 'woocommerce-gateway-amazon-payments-advanced' ),
 				'type'        => 'title',
-				'description' => $button_desc . '<br/><br/>' . $button_btn,
+				'description' => $button_desc . ( $button_note ? '<br/><br/>' . $button_note : '' ) . '<br/><br/>' . $button_btn,
 			),
 			'enabled'                     => array(
 				'title'       => __( 'Enable/Disable', 'woocommerce-gateway-amazon-payments-advanced' ),
@@ -1086,29 +1092,31 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 			return $option_value;
 		}
 
-        return $this->phone_number_is_required() ? 'required' : $option_value;
+		return $this->phone_number_is_required() ? 'required' : $option_value;
 	}
 
-    /**
-     * The phone number field is required for Amazon Pay
-     * @return bool
-     */
-    public function phone_number_is_required() {
-        return ( ! empty( WC()->cart ) ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping();
-    }
+	/**
+	 * The phone number field is required for Amazon Pay
+	 *
+	 * @return bool
+	 */
+	public function phone_number_is_required() {
+		return ( ! empty( WC()->cart ) ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping();
+	}
 
-    /**
-     * Indicates whether the phone was required without taking Amazon Pay into account
-     * @return bool
-     */
-    public function phone_number_is_required_base() {
+	/**
+	 * Indicates whether the phone was required without taking Amazon Pay into account
+	 *
+	 * @return bool
+	 */
+	public function phone_number_is_required_base() {
 		self::$suppress_phone_filter = true;
 		/** @see \Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::get_core_fields */
-		$base_phone_required = 'required' === CartCheckoutUtils::get_phone_field_visibility();
+		$base_phone_required         = 'required' === CartCheckoutUtils::get_phone_field_visibility();
 		self::$suppress_phone_filter = false;
 
-        return $base_phone_required;
-    }
+		return $base_phone_required;
+	}
 
 	/**
 	 * Init common hooks on checkout_init hook

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -1061,6 +1061,15 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 			return $option_value;
 		}
 
+		$chosen_payment = ( WC()->session instanceof WC_Session ) ? WC()->session->get( 'chosen_payment_method' ) : null;
+		if ( empty( $chosen_payment ) && isset( $_POST['payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$chosen_payment = sanitize_text_field( wp_unslash( $_POST['payment_method'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		}
+
+		if ( $this->id !== $chosen_payment ) {
+			return $option_value;
+		}
+
 		if ( empty( WC()->cart ) ) {
 			return $option_value;
 		}

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -1075,11 +1075,7 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 			return $option_value;
 		}
 
-		if ( ! method_exists( WC()->cart, 'needs_shipping' ) || ! WC()->cart->needs_shipping() ) {
-			return $option_value;
-		}
-
-		return 'required';
+        return $this->phone_number_is_required() ? 'required' : $option_value;
 	}
 
     /**

--- a/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced-abstract.php
@@ -1081,6 +1081,14 @@ abstract class WC_Gateway_Amazon_Payments_Advanced_Abstract extends WC_Payment_G
 		return 'required';
 	}
 
+    /**
+     * The phone number field is required for Amazon Pay
+     * @return bool
+     */
+    public function phone_number_is_required() {
+        return ( ! empty( WC()->cart ) ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping();
+    }
+
 	/**
 	 * Init common hooks on checkout_init hook
 	 */

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1586,7 +1586,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
         if ( ! $order->needs_payment() ) {
             wc_apa()->log( sprintf( 'Order #%d does not need payment. Skipping checkout session completion for %s.', $order_id, $checkout_session_id ) );
-            wp_safe_redirect( wc_get_checkout_url() );
+            wp_safe_redirect( wc_apa()->get_gateway()->get_return_url( $order ) );
             exit;
         }
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1586,7 +1586,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
         if ( ! $order->needs_payment() ) {
             wc_apa()->log( sprintf( 'Order #%d does not need payment. Skipping checkout session completion for %s.', $order_id, $checkout_session_id ) );
-            wp_safe_redirect( $order->get_checkout_order_received_url() );
+            wp_safe_redirect( wc_get_checkout_url() );
             exit;
         }
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -297,6 +297,8 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'ledger_currency'                => $this->get_ledger_currency(),
 				'estimated_order_amount'         => self::get_estimated_order_amount(),
 				'overriden_fields_per_country'   => WC_Amazon_Payments_Advanced_Utils::get_non_required_fields_per_country(),
+				'phone_required'                 => $this->phone_number_is_required(),
+				'phone_required_base'            => $this->phone_number_is_required_base(),
 			),
 			$params
 		);

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2211,7 +2211,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 		}
 
 		if ( is_wp_error( $checkout_session ) || ! isset($checkout_session->statusDetails) || 'Open' !== ( $checkout_session->statusDetails->state ?? null ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			return new WP_Error( 'not_open', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $checkout_session->statusDetails->state ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			return new WP_Error( 'not_open', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $checkout_session->statusDetails->state ?? null ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 
 		if ( $checkout_session->productType !== $this->get_current_cart_action() ) { // phpcs:ignore WordPress.NamingConventions

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -790,12 +790,14 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 			if ( ! is_user_logged_in() ) {
 				$checkout_session = $this->get_checkout_session();
-				$buyer_id         = $checkout_session->buyer->buyerId;
+				if ( ! is_wp_error( $checkout_session ) && isset( $checkout_session->buyer ) && ! empty( $checkout_session->buyer->buyerId ) ) {
+					$buyer_id = $checkout_session->buyer->buyerId;
 
-				$buyer_user_id = $this->get_customer_id_from_buyer( $buyer_id );
+					$buyer_user_id = $this->get_customer_id_from_buyer( $buyer_id );
 
-				if ( ! empty( $buyer_user_id ) ) {
-					wc_set_customer_auth_cookie( $buyer_user_id );
+					if ( ! empty( $buyer_user_id ) ) {
+						wc_set_customer_auth_cookie( $buyer_user_id );
+					}
 				}
 			}
 
@@ -2176,7 +2178,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	/**
 	 * Check wether the checkout session is still valid.
 	 *
-	 * @param  object $checkout_session Checkout Session Object from the Amazon API.
+	 * @param  object|WP_Error $checkout_session Checkout Session Object from the Amazon API.
 	 * @return bool|WP_Error True if valid, WP_Error in case of error.
 	 */
 	public function is_checkout_session_still_valid( $checkout_session ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -2191,7 +2191,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			return new WP_Error( 'session_changed', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $props_validation->get_error_data() );
 		}
 
-		if ( 'Open' !== $checkout_session->statusDetails->state ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		if ( is_wp_error( $checkout_session ) || ! isset($checkout_session->statusDetails) || 'Open' !== ( $checkout_session->statusDetails->state ?? null ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			return new WP_Error( 'not_open', __( 'Something went wrong with your session. Please log in again.', 'woocommerce-gateway-amazon-payments-advanced' ), $checkout_session->statusDetails->state ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1608,7 +1608,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		if ( ! $this->get_lock_for_order( $order_id ) ) {
             wc_apa()->log( sprintf( 'Order #%d is already being processed. Aborting duplicate handle_return for %s.', $order_id, $checkout_session_id ) );
-            wp_safe_redirect( $order->get_checkout_order_received_url() );
+            wp_safe_redirect( wc_get_checkout_url() );
 			exit;
 		}
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1606,7 +1606,11 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		wc_apa()->log( "Completing checkout session data for #{$order_id}." );
 
-		$this->get_lock_for_order( $order_id, true );
+		if ( ! $this->get_lock_for_order( $order_id ) ) {
+            wc_apa()->log( sprintf( 'Order #%d is already being processed. Aborting duplicate handle_return for %s.', $order_id, $checkout_session_id ) );
+            wp_safe_redirect( $order->get_checkout_order_received_url() );
+			exit;
+		}
 
 		$charge_amount = array(
 			'amount'       => $order_total,

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1584,6 +1584,12 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
             return;
         }
 
+        if ( ! $order->needs_payment() ) {
+            wc_apa()->log( sprintf( 'Order #%d does not need payment. Skipping checkout session completion for %s.', $order_id, $checkout_session_id ) );
+            wp_safe_redirect( $order->get_checkout_order_received_url() );
+            exit;
+        }
+
 		$order_total = WC_Amazon_Payments_Advanced::format_amount( $order->get_total() );
 		$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -791,7 +791,6 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 			if ( ! is_user_logged_in() ) {
 				$checkout_session = $this->get_checkout_session();
 				$buyer_id         = $checkout_session->buyer->buyerId;
-				$buyer_email      = $checkout_session->buyer->email;
 
 				$buyer_user_id = $this->get_customer_id_from_buyer( $buyer_id );
 

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -833,7 +833,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 	 *
 	 * @param  mixed       $force Wether to force read from amazon, or use the cached data if available.
 	 * @param  null|string $checkout_session_id The checkout session id if it exists.
-	 * @return object the Checkout Session Object from Amazon API
+	 * @return object|WP_Error the Checkout Session Object from Amazon API
 	 */
 	public function get_checkout_session( $force = false, $checkout_session_id = null ) {
 		if ( ! $force && null !== $this->checkout_session ) {

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -299,6 +299,7 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 				'overriden_fields_per_country'   => WC_Amazon_Payments_Advanced_Utils::get_non_required_fields_per_country(),
 				'phone_required'                 => $this->phone_number_is_required(),
 				'phone_required_base'            => $this->phone_number_is_required_base(),
+				'i18n_optional'                  => esc_html__( 'optional', 'woocommerce-gateway-amazon-payments-advanced' ),
 			),
 			$params
 		);

--- a/includes/class-wc-gateway-amazon-payments-advanced.php
+++ b/includes/class-wc-gateway-amazon-payments-advanced.php
@@ -1578,6 +1578,12 @@ class WC_Gateway_Amazon_Payments_Advanced extends WC_Gateway_Amazon_Payments_Adv
 
 		$order = wc_get_order( $order_id );
 
+        if ( ! is_a( $order, WC_Order::class ) ) {
+            wc_apa()->log( "Error: Order with ID {$order_id} could not be loaded. Checkout Session ID: {$checkout_session_id}." );
+            wc_add_notice( __( 'There was an error while processing your payment. Please try again. If the error persist, please contact us about your order.', 'woocommerce-gateway-amazon-payments-advanced' ), 'error' );
+            return;
+        }
+
 		$order_total = WC_Amazon_Payments_Advanced::format_amount( $order->get_total() );
 		$currency    = wc_apa_get_order_prop( $order, 'order_currency' );
 

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
@@ -43,7 +43,6 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 	 * @return array
 	 */
 	public function get_payment_method_data() {
-		$phone_required = ! empty( WC()->cart ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping(); // TODO: use reusable service
 		return array(
 			'title'               => $this->settings['title'],
 			'description'         => $this->settings['description'],
@@ -51,7 +50,8 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 			'amazonPayPreviewUrl' => esc_url( wc_apa()->plugin_url . '/build/images/amazon-pay-preview.png' ),
 			'action'              => wc_apa()->get_gateway()->get_current_cart_action(),
 			'allowedCurrencies'   => $this->get_allowed_currencies(),
-			'phoneRequired'       => $phone_required,
+			'phoneRequired'       => wc_apa()->get_gateway()->phone_number_is_required(),
+			'phoneRequiredBase'   => wc_apa()->get_gateway()->phone_number_is_required_base(),
 		);
 	}
 

--- a/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
+++ b/includes/compats/woo-blocks/class-wc-amazon-payments-advanced-block-compat-classic.php
@@ -43,6 +43,7 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 	 * @return array
 	 */
 	public function get_payment_method_data() {
+		$phone_required = ! empty( WC()->cart ) && method_exists( WC()->cart, 'needs_shipping' ) && WC()->cart->needs_shipping(); // TODO: use reusable service
 		return array(
 			'title'               => $this->settings['title'],
 			'description'         => $this->settings['description'],
@@ -50,6 +51,7 @@ class WC_Amazon_Payments_Advanced_Block_Compat_Classic extends WC_Amazon_Payment
 			'amazonPayPreviewUrl' => esc_url( wc_apa()->plugin_url . '/build/images/amazon-pay-preview.png' ),
 			'action'              => wc_apa()->get_gateway()->get_current_cart_action(),
 			'allowedCurrencies'   => $this->get_allowed_currencies(),
+			'phoneRequired'       => $phone_required,
 		);
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-gateway-amazon-payments-advanced",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-gateway-amazon-payments-advanced",
-      "version": "2.5.4",
+      "version": "2.6.2",
       "hasInstallScript": true,
       "license": "GPL-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-gateway-amazon-payments-advanced",
-  "version": "2.6.2",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-gateway-amazon-payments-advanced",
-  "version": "2.6.2",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-gateway-amazon-payments-advanced",
-      "version": "2.6.2",
+      "version": "2.6.1",
       "hasInstallScript": true,
       "license": "GPL-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-gateway-amazon-payments-advanced",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-amazon-payments-advanced",
   "description": "Amazon Pay Gateway for WooCommerce",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "title": "WooCommerce Gateway Amazon Pay",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-amazon-payments-advanced",
   "description": "Amazon Pay Gateway for WooCommerce",
-  "version": "2.6.2",
+  "version": "2.6.1",
   "title": "WooCommerce Gateway Amazon Pay",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: amazonpay, woocommerce, automattic, saucal, woothemes, akeda, jeffstieler, mikejolley, bor0, claudiosanches, royho, jamesrrodger, laurendavissmith001, dwainm, danreylop
 Tags: woocommerce, amazon, checkout, payments, e-commerce, ecommerce
 Requires at least: 5.5
-Tested up to: 6.9
+Tested up to: 7.0.1
 Stable tag: 2.6.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -79,6 +79,15 @@ WordPress codex contains [instructions on how to do this here](http://codex.word
 Automatic updates should work like a charm; as always though, ensure you backup your site just in case.
 
 == Changelog ==
+
+= 2.6.2 - 2026-xx-xx =
+
+* Fix - Fatal error in the IPN handler (v2) when the related order could not be retrieved.
+* Fix - Amazon Pay incorrectly requiring the phone number for all payment methods.
+* Fix - Prevent duplicate charges when paying with Amazon Pay on Classic Checkout.
+* Fix - PHP warnings and errors.
+* Dev - Removed pinned Composer version to address a potential security vulnerability.
+* Dev - Bumped required PHP version to 7.4.
 
 = 2.6.1 - 2026-01-21 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,8 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 * Fix - PHP warnings and errors.
 * Dev - Removed pinned Composer version to address a potential security vulnerability.
 * Dev - Bumped required PHP version to 7.4.
+* Dev - Bumped tested up to WordPress v7.0.1.
+* Dev - Bumped tested up to WooCommerce v10.8.1.
 
 = 2.6.1 - 2026-01-21 =
 

--- a/src/js/non-block/amazon-wc-checkout.js
+++ b/src/js/non-block/amazon-wc-checkout.js
@@ -424,7 +424,7 @@
 				$label.append( '<span class="required" aria-hidden="true">*</span>' );
 			} else {
 				$field.removeAttr( 'required' );
-				$label.append( '<span class="optional">(optional)</span>' );
+				$label.append( '<span class="optional">(' + amazon_payments_advanced.i18n_optional + ')</span>' );
 			}
 		}
 

--- a/src/js/non-block/amazon-wc-checkout.js
+++ b/src/js/non-block/amazon-wc-checkout.js
@@ -416,9 +416,37 @@
 			$( '.wc-apa-send-confirm-ownership-code' ).on( 'click', sendConfirmationCode );
 		}
 
+		function updatePhoneFieldRequired( $field, isRequired ) {
+			var $label = $( 'label[for="' + $field.attr( 'id' ) + '"]' );
+			$label.find( 'span.required, span.optional' ).remove();
+			if ( isRequired ) {
+				$field.attr( 'required', '' );
+				$label.append( '<span class="required" aria-hidden="true">*</span>' );
+			} else {
+				$field.removeAttr( 'required' );
+				$label.append( '<span class="optional">(optional)</span>' );
+			}
+		}
+
+		function updatePhoneRequired() {
+			var phoneRequired = amazon_payments_advanced.phone_required;
+			var phoneRequiredBase = amazon_payments_advanced.phone_required_base;
+
+			if ( ! phoneRequired || phoneRequiredBase ) {
+				return;
+			}
+
+			var isAmazon = 'amazon_payments_advanced' === $( 'input[name=payment_method]:checked' ).val();
+			updatePhoneFieldRequired( $( '#billing_phone' ), isAmazon );
+			updatePhoneFieldRequired( $( '#shipping_phone' ), isAmazon );
+		}
+
 		initAmazonPaymentFields();
 
 		$( 'body' ).on( 'updated_checkout', initAmazonPaymentFields );
-		$( 'body' ).on( 'payment_method_selected', initAmazonPaymentFields );
+		$( 'body' ).on( 'payment_method_selected', function() {
+			initAmazonPaymentFields();
+			updatePhoneRequired();
+		} );
 	} );
 } )( jQuery );

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -18,7 +18,7 @@ import { renderAndInitAmazonCheckout } from '../../_renderAmazonButton';
  * @returns React component
  */
 const AmazonPayBtn = ( props ) => {
-	const { action, phoneRequired } = settings;
+	const { action, phoneRequired, phoneRequiredBase } = settings;
 
 	useEffect( () => {
 		const unsubscribe = props.eventRegistration.onCheckoutSuccess(
@@ -41,32 +41,46 @@ const AmazonPayBtn = ( props ) => {
 	] );
 
 	useEffect( () => {
-		if ( 'PayOnly' === action ) {
+		if ( 'PayOnly' === action || ! phoneRequired || phoneRequiredBase ) {
 			return;
 		}
-		if ( ! phoneRequired ) {
-			return;
-		}
+		const defaultFieldsSettings = window.wc?.wcSettings?.getSetting?.( 'defaultFields', {} );
+		const phoneLabel = defaultFieldsSettings?.phone?.label || __( 'Phone', 'woocommerce-gateway-amazon-payments-advanced' );
+		const phoneOptionalLabel = defaultFieldsSettings?.phone?.optionalLabel || __( 'Phone (optional)', 'woocommerce-gateway-amazon-payments-advanced' );
+
 		const phoneIds = [ 'billing-phone', 'shipping-phone' ];
+		const wcDefaultPhone = window.wc?.wcSettings?.defaultFields?.phone;
+
+		if ( wcDefaultPhone ) {
+			wcDefaultPhone.required = true;
+		}
 		phoneIds.forEach( ( id ) => {
 			const field = document.getElementById( id );
-			if ( field ) {
-				field.setAttribute( 'required', '' );
-				const label = document.querySelector( `label[for="${ id }"]` );
-				if ( field ) {
-					label.innerHTML = __( 'Phone', 'woocommerce-gateway-amazon-payments-advanced' );
-				}
+			if ( ! field ) {
+				return;
+			}
+			field.setAttribute( 'required', '' );
+			const label = document.querySelector( `label[for="${ id }"]` );
+			if ( label ) {
+				label.textContent = phoneLabel;
 			}
 		} );
+
 		return () => {
+			// Restore defaultFields to the base WC option value so fields that appear after
+			// Amazon Pay is deselected (e.g. billing-phone after same-address toggle) render correctly.
+			if ( wcDefaultPhone ) {
+				wcDefaultPhone.required = false;
+			}
 			phoneIds.forEach( ( id ) => {
 				const field = document.getElementById( id );
-				if ( field ) {
-					field.removeAttribute( 'required' );
-					const label = document.querySelector( `label[for="${ id }"]` );
-					if ( field ) {
-						label.innerHTML = __( 'Phone (optional)', 'woocommerce-gateway-amazon-payments-advanced' );
-					}
+				if ( ! field ) {
+					return;
+				}
+				field.removeAttribute( 'required' );
+				const label = document.querySelector( `label[for="${ id }"]` );
+				if ( label ) {
+					label.textContent = phoneOptionalLabel;
 				}
 			} );
 		};
@@ -80,7 +94,7 @@ const AmazonPayBtn = ( props ) => {
 				}
 				const shippingPhone = document.getElementById( 'shipping-phone' );
 				const billingPhone = document.getElementById( 'billing-phone' );
-				
+
 				if ( ! shippingPhone?.value && ! billingPhone?.value ) {
 					return {
 						type: 'error',

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -18,7 +18,7 @@ import { renderAndInitAmazonCheckout } from '../../_renderAmazonButton';
  * @returns React component
  */
 const AmazonPayBtn = ( props ) => {
-	const { action } = settings;
+	const { action, phoneRequired } = settings;
 
 	useEffect( () => {
 		const unsubscribe = props.eventRegistration.onCheckoutSuccess(
@@ -42,6 +42,9 @@ const AmazonPayBtn = ( props ) => {
 
 	useEffect( () => {
 		if ( 'PayOnly' === action ) {
+			return;
+		}
+		if ( ! phoneRequired ) {
 			return;
 		}
 		const phoneIds = [ 'billing-phone', 'shipping-phone' ];

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -41,6 +41,27 @@ const AmazonPayBtn = ( props ) => {
 	] );
 
 	useEffect( () => {
+		if ( 'PayOnly' === action ) {
+			return;
+		}
+		const phoneIds = [ 'billing-phone', 'shipping-phone' ];
+		phoneIds.forEach( ( id ) => {
+			const field = document.getElementById( id );
+			if ( field ) {
+				field.setAttribute( 'required', '' );
+			}
+		} );
+		return () => {
+			phoneIds.forEach( ( id ) => {
+				const field = document.getElementById( id );
+				if ( field ) {
+					field.removeAttribute( 'required' );
+				}
+			} );
+		};
+	}, [ action ] );
+
+	useEffect( () => {
 		const unsubscribe = props.eventRegistration.onPaymentSetup(
 			async () => {
 				if ( 'PayOnly' === action ) {

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -44,45 +44,16 @@ const AmazonPayBtn = ( props ) => {
 		if ( 'PayOnly' === action || ! phoneRequired || phoneRequiredBase ) {
 			return;
 		}
-		const defaultFieldsSettings = window.wc?.wcSettings?.getSetting?.( 'defaultFields', {} );
-		const phoneLabel = defaultFieldsSettings?.phone?.label || __( 'Phone', 'woocommerce-gateway-amazon-payments-advanced' );
-		const phoneOptionalLabel = defaultFieldsSettings?.phone?.optionalLabel || __( 'Phone (optional)', 'woocommerce-gateway-amazon-payments-advanced' );
 
-		const phoneIds = [ 'billing-phone', 'shipping-phone' ];
 		const wcDefaultPhone = window.wc?.wcSettings?.defaultFields?.phone;
-
 		if ( wcDefaultPhone ) {
 			wcDefaultPhone.required = true;
 		}
-		phoneIds.forEach( ( id ) => {
-			const field = document.getElementById( id );
-			if ( ! field ) {
-				return;
-			}
-			field.setAttribute( 'required', '' );
-			const label = document.querySelector( `label[for="${ id }"]` );
-			if ( label ) {
-				label.textContent = phoneLabel;
-			}
-		} );
 
 		return () => {
-			// Restore defaultFields to the base WC option value so fields that appear after
-			// Amazon Pay is deselected (e.g. billing-phone after same-address toggle) render correctly.
 			if ( wcDefaultPhone ) {
 				wcDefaultPhone.required = false;
 			}
-			phoneIds.forEach( ( id ) => {
-				const field = document.getElementById( id );
-				if ( ! field ) {
-					return;
-				}
-				field.removeAttribute( 'required' );
-				const label = document.querySelector( `label[for="${ id }"]` );
-				if ( label ) {
-					label.textContent = phoneOptionalLabel;
-				}
-			} );
 		};
 	}, [ action ] );
 

--- a/src/js/payments-methods/classic/_payment-methods.js
+++ b/src/js/payments-methods/classic/_payment-methods.js
@@ -49,6 +49,10 @@ const AmazonPayBtn = ( props ) => {
 			const field = document.getElementById( id );
 			if ( field ) {
 				field.setAttribute( 'required', '' );
+				const label = document.querySelector( `label[for="${ id }"]` );
+				if ( field ) {
+					label.innerHTML = __( 'Phone', 'woocommerce-gateway-amazon-payments-advanced' );
+				}
 			}
 		} );
 		return () => {
@@ -56,6 +60,10 @@ const AmazonPayBtn = ( props ) => {
 				const field = document.getElementById( id );
 				if ( field ) {
 					field.removeAttribute( 'required' );
+					const label = document.querySelector( `label[for="${ id }"]` );
+					if ( field ) {
+						label.innerHTML = __( 'Phone (optional)', 'woocommerce-gateway-amazon-payments-advanced' );
+					}
 				}
 			} );
 		};

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -3,7 +3,7 @@
  * Plugin Name: Amazon Pay for WooCommerce
  * Plugin URI: https://woocommerce.com/products/pay-with-amazon/
  * Description: Amazon Pay is embedded directly into your existing web site, and all the buyer interactions with Amazon Pay and Login with Amazon take place in embedded widgets so that the buyer never leaves your site. Buyers can log in using their Amazon account, select a shipping address and payment method, and then confirm their order. Requires an Amazon Pay seller account and supports USA, UK, Germany, France, Italy, Spain, Luxembourg, the Netherlands, Sweden, Portugal, Hungary, Denmark, and Japan.
- * Version: 2.6.2
+ * Version: 2.6.1
  * Author: Amazon Pay
  * Author URI: https://pay.amazon.com/
  * Text Domain: woocommerce-gateway-amazon-payments-advanced

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -9,7 +9,7 @@
  * Text Domain: woocommerce-gateway-amazon-payments-advanced
  * Domain Path: /languages/
  * Tested up to: 7.0.1
- * WC tested up to: 10.9.4
+ * WC tested up to: 10.8.1
  * WC requires at least: 4.0
  * Requires PHP: 7.4
  *

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -11,6 +11,7 @@
  * Tested up to: 6.9
  * WC tested up to: 10.4.3
  * WC requires at least: 4.0
+ * Requires PHP: 7.4
  *
  * Copyright: © 2026 WooCommerce
  * License: GNU General Public License v3.0

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -8,8 +8,8 @@
  * Author URI: https://pay.amazon.com/
  * Text Domain: woocommerce-gateway-amazon-payments-advanced
  * Domain Path: /languages/
- * Tested up to: 6.9
- * WC tested up to: 10.4.3
+ * Tested up to: 7.0.1
+ * WC tested up to: 10.9.4
  * WC requires at least: 4.0
  * Requires PHP: 7.4
  *

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -19,7 +19,7 @@
  * @package WC_Gateway_Amazon_Pay
  */
 
-define( 'WC_AMAZON_PAY_VERSION', '2.6.1' ); // WRCS: DEFINED_VERSION.
+define( 'WC_AMAZON_PAY_VERSION', '2.6.2' ); // WRCS: DEFINED_VERSION.
 define( 'WC_AMAZON_PAY_VERSION_CV1', '1.13.1' );
 
 // Declare HPOS compatibility.

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -3,7 +3,7 @@
  * Plugin Name: Amazon Pay for WooCommerce
  * Plugin URI: https://woocommerce.com/products/pay-with-amazon/
  * Description: Amazon Pay is embedded directly into your existing web site, and all the buyer interactions with Amazon Pay and Login with Amazon take place in embedded widgets so that the buyer never leaves your site. Buyers can log in using their Amazon account, select a shipping address and payment method, and then confirm their order. Requires an Amazon Pay seller account and supports USA, UK, Germany, France, Italy, Spain, Luxembourg, the Netherlands, Sweden, Portugal, Hungary, Denmark, and Japan.
- * Version: 2.6.1
+ * Version: 2.6.2
  * Author: Amazon Pay
  * Author URI: https://pay.amazon.com/
  * Text Domain: woocommerce-gateway-amazon-payments-advanced

--- a/woocommerce-gateway-amazon-payments-advanced.php
+++ b/woocommerce-gateway-amazon-payments-advanced.php
@@ -9,8 +9,8 @@
  * Text Domain: woocommerce-gateway-amazon-payments-advanced
  * Domain Path: /languages/
  * Tested up to: 6.9
- * WC tested up to: 10.4.3
- * WC requires at least: 4.0
+ * WC tested up to: 10.8.1
+ * WC requires at least: 8.5
  *
  * Copyright: © 2026 WooCommerce
  * License: GNU General Public License v3.0


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [Extendables](https://extendomattic.wordpress.com/standardizations/) standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Release PR for **Amazon Pay v2.6.2**, merging `release/2.6.2` into `main`. Bumps plugin version and rolls up the fixes tracked under [ClickUp: Version 2.6.2](https://app.clickup.com/t/86dyve98e):

- Fix onboarding incompatibility with PHP 8.5 ([w#339](https://app.clickup.com/t/86e1t7dub))
- Fix PHP 8.4 warnings/fatal errors when the Amazon checkout session fails to load ([w#320](https://app.clickup.com/t/86e12vb1k))
- Fix fatal error in the IPN handler (v2) when the related order could not be retrieved ([w#319](https://app.clickup.com/t/86e0mrea7))
- Fix Amazon Pay incorrectly requiring the phone number for all payment methods ([w#313](https://app.clickup.com/t/86dy7jgmb))
- Fix duplicate charges on Classic Checkout ([task](https://app.clickup.com/t/86dx8u947))
- Remove pinned Composer version to address a potential security vulnerability ([task](https://app.clickup.com/t/86e1hqngj))
- Bump required PHP version to 7.4; drop PHP 7.3 from the CI test matrix ([task](https://app.clickup.com/t/86e1jqp6z))

Closes # .

### How to test the changes in this Pull Request:

1. Install the plugin on PHP 7.4 and PHP 8.4/8.5, confirm no fatal errors/warnings on merchant onboarding or checkout session load.
2. Run a Classic Checkout purchase with Amazon Pay and confirm the order is charged only once.
3. Select different payment methods at checkout and confirm the phone field is only required when Amazon Pay is selected.
4. Trigger an Amazon Pay IPN for an order that no longer exists / can't be loaded, confirm no fatal error is thrown.
5. Run `composer install` and confirm it resolves without the previously pinned Composer version.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> = 2.6.2 =
>
> * Fix - Fatal error in the IPN handler (v2) when the related order could not be retrieved.
> * Fix - Amazon Pay incorrectly requiring the phone number for all payment methods.
> * Fix - Prevent duplicate charges when paying with Amazon Pay on Classic Checkout.
> * Fix - PHP warnings and errors.
> * Dev - Removed pinned Composer version to address a potential security vulnerability.
> * Dev - Bumped required PHP version to 7.4.
