### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/php-unit-on-pr.yml
+++ b/.github/workflows/php-unit-on-pr.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # PHP setup
       - name: Setup PHP ${{ matrix.php }}
@@ -37,14 +37,14 @@ jobs:
 
       # Use node version from .nvmrc
       - name: Setup NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: '.nvmrc'
 
       # Cache composer dependencies
       - name: Cache composer dependencies
         id: composer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ./vendor
           key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
@@ -52,7 +52,7 @@ jobs:
       # Cache node dependencies
       - name: Cache node dependencies
         id: node-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ./node_modules
           key:  ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
### Changes proposed in this Pull Request

The WooCommerce GitHub organization intends to enforce full-commit-SHA pinning for GitHub Actions. This change replaces every mutable external Action tag or branch used by this repository with the current 40-character commit SHA and preserves the original human-readable ref in a trailing comment.

Immutable pins reduce supply-chain compromise risk if an upstream tag or branch is moved or an Action repository is compromised. Local actions and reusable workflows remain unchanged.

### Verification

- [x] Re-audited the current default branch and pinned every mutable external Action reference.
- [x] Independently re-resolved each distinct tag or branch and confirmed it matches the pinned SHA.
- [x] Confirmed the post-change scan reports zero mutable external Action references.
- [x] Parsed every changed workflow and composite-action YAML file successfully.
- [x] Ran git diff --check.
- [x] Confirmed the diff contains only intended uses: reference changes.

### Backward compatibility impact

No backward-compatibility impact. This changes CI and automation configuration only.

### Changelog

No changelog entry is needed because this is a workflow-only configuration change with no product or runtime behavior change.

### Test steps

1. Inspect each changed uses: reference and confirm it is a full 40-character SHA with the original ref in a trailing comment.
2. Confirm repository workflows and composite actions load successfully in GitHub Actions.
3. Confirm the post-change SHA-pin scan reports zero findings.