### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/php-unit-on-pr.yml
+++ b/.github/workflows/php-unit-on-pr.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     name: PHP Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         php: [ 7.4, 8.0, 8.1 ]


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `test` (PHP Unit Tests) | 1.4 min | 1.5 min | 5 |

Part of TESTOPS-272